### PR TITLE
fix(ci): isolate workflow_dispatch from push concurrency in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
         default: ""
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}${{ inputs.tag_name && format('-{0}', inputs.tag_name) || '' }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}${{ github.event_name == 'workflow_dispatch' && inputs.tag_name && format('-{0}', inputs.tag_name) || '' }}
   cancel-in-progress: ${{ github.event_name == 'push' }}
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ on:
         default: ""
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}${{ inputs.tag_name && format('-{0}', inputs.tag_name) || '' }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 permissions:
   contents: write


### PR DESCRIPTION
Sync from dcc-mcp-core v0.18.6 ([792a1f7](https://github.com/dcc-mcp/dcc-mcp-core/commit/792a1f752a149e3db7bf3c56eee6d92cd50060e8)).

## What
Split the concurrency group key to include `github.event_name` and the optional `tag_name` input. Also make `cancel-in-progress` conditional on `push` events only.

## Why
A new push to main could cancel an operator-started manual `workflow_dispatch` build run.

## Changes
- `group`: adds `-${{ github.event_name }}` and `${{ inputs.tag_name && format('-{0}', inputs.tag_name) || '' }}`
- `cancel-in-progress`: changed from `true` to `${{ github.event_name == 'push' }}`

## Risk
Low — only changes concurrency cancellation behavior. Push and workflow_dispatch runs get separate group keys.