### PR TITLE
chore: bump dcc-mcp-core dependency to >=0.18.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 
 dependencies = [
     "adobepy>=0.1.0",
-    "dcc-mcp-core>=0.18.2,<1.0.0",
+    "dcc-mcp-core>=0.18.7,<1.0.0",
     "websockets>=12.0",
 ]
 


### PR DESCRIPTION
## Summary
- Bump `dcc-mcp-core` dependency from `>=0.18.2` to `>=0.18.7` to align with core v0.18.7 release train
- All 149 adapter tests pass (5 skipped — method map contract file not in repo)
- No code changes required — marketplace schema, gateway discovery, model description parsing changes are all transparent to this adapter via `DccServerBase`

## Changes
- `pyproject.toml`: `dcc-mcp-core>=0.18.2,<1.0.0` → `dcc-mcp-core>=0.18.7,<1.0.0`

## Test plan
- [x] Full test suite: 149 passed, 5 skipped
- [x] Adapter imports and core API surface verified
- [x] Marketplace compatibility verified (transparent via DccServerBase)
- [x] Gateway discovery verified (no DccServerBase API changes in range)
- [x] Model description parsing — not used by this adapter

Linked GitHub issues: none
