### PR TITLE
chore(deps): bump dcc-mcp-core to >=0.18.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 
 dependencies = [
     "adobepy>=0.1.0",
-    "dcc-mcp-core>=0.18.7,<1.0.0",
+    "dcc-mcp-core>=0.18.9,<1.0.0",
     "websockets>=12.0",
 ]
 


### PR DESCRIPTION
## Summary
- Bump `dcc-mcp-core` dependency from `>=0.18.7,<1.0.0` to `>=0.18.9,<1.0.0`
- Release Train v0.18.0..v0.18.9: marketplace shared crate, gateway election disabled for probe server, ADR-010 dual-protocol migration docs

## Related
- Core release: https://github.com/dcc-mcp/dcc-mcp-core/releases/tag/v0.18.9