### PR TITLE
fix: ruff import organization in test_agent_instruction_files.py

### DIFF
--- a/tests/test_agent_instruction_files.py
+++ b/tests/test_agent_instruction_files.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import subprocess
-
+from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 AGENT_ENTRYPOINTS = (

--- a/tests/test_agent_instruction_files.py
+++ b/tests/test_agent_instruction_files.py
@@ -52,9 +52,6 @@ def test_multica_runtime_artifacts_are_not_tracked() -> None:
     offenders = [
         path
         for path in tracked
-        if any(
-            path == prefix.rstrip("/") or path.startswith(prefix)
-            for prefix in FORBIDDEN_TRACKED_PREFIXES
-        )
+        if any(path == prefix.rstrip("/") or path.startswith(prefix) for prefix in FORBIDDEN_TRACKED_PREFIXES)
     ]
     assert offenders == []


### PR DESCRIPTION
## Summary
Fix Ruff lint failure (I001) on `main` — `import subprocess` must precede `from pathlib import Path` per import ordering rules.

## CI
- Fixes the failing CI (Lint) workflow: https://github.com/dcc-mcp/dcc-mcp-photoshop/actions/runs/27094671542