### PR TITLE
feat: define Photoshop UXP WebSocket bridge protocol v0.1.0

### DIFF
--- a/bridge/uxp-plugin/src/bridge-client.js
+++ b/bridge/uxp-plugin/src/bridge-client.js
@@ -5,7 +5,8 @@
  * Receives JSON-RPC 2.0 requests from Python, dispatches to PS handlers,
  * and sends back responses.
  *
- * Reconnects automatically if the connection drops.
+ * Implements the Photoshop bridge protocol v0.
+ * See: docs/bridge-protocol.md
  */
 
 "use strict";
@@ -13,9 +14,19 @@
 const documentHandlers = require("./handlers/document");
 const layerHandlers    = require("./handlers/layers");
 const scriptHandlers   = require("./handlers/script");
-const { rpcSuccess, rpcError, parseRequest, RPC_METHOD_NOT_FOUND, RPC_INTERNAL_ERROR } = require("./utils/jsonrpc");
+const {
+    PROTOCOL_VERSION,
+    RPC_METHOD_NOT_FOUND,
+    RPC_INTERNAL_ERROR,
+    buildHello,
+    rpcSuccess,
+    rpcError,
+    parseRequest,
+    isHelloAck,
+    isDisconnected,
+} = require("./utils/jsonrpc");
 
-// Python bridge server — must match bridge.py BRIDGE_SERVER_PORT
+// Python bridge server — must match bridge.py DEFAULT_SERVER_PORT
 const BRIDGE_URL = "ws://localhost:9001";
 const RECONNECT_DELAY_MS = 3000;
 
@@ -25,6 +36,7 @@ const HANDLERS = Object.assign({}, documentHandlers, layerHandlers, scriptHandle
 let _ws = null;
 let _reconnectTimer = null;
 let _stopped = false;
+let _reconnecting = false;
 let _statusCallback = null;
 
 function _setStatus(status, detail) {
@@ -32,27 +44,16 @@ function _setStatus(status, detail) {
     if (_statusCallback) _statusCallback(status, detail);
 }
 
-/**
- * Register a callback for status changes.
- * @param {function(status: string, detail?: string): void} cb
- */
 function onStatusChange(cb) {
     _statusCallback = cb;
 }
 
-/**
- * Dispatch a JSON-RPC request to the appropriate Photoshop handler.
- * @param {object} request
- * @returns {Promise<object>} JSON-RPC response
- */
 async function _dispatch(request) {
     const { id, method, params = {} } = request;
     const handler = HANDLERS[method];
-
     if (!handler) {
         return rpcError(id, RPC_METHOD_NOT_FOUND, `Method not found: ${method}`);
     }
-
     try {
         const result = await handler(params);
         return rpcSuccess(id, result);
@@ -62,17 +63,12 @@ async function _dispatch(request) {
     }
 }
 
-/**
- * Connect to the Python WebSocket bridge server.
- */
 function connect() {
     if (_ws && (_ws.readyState === WebSocket.OPEN || _ws.readyState === WebSocket.CONNECTING)) {
         return;
     }
-
     _stopped = false;
     _setStatus("Connecting", BRIDGE_URL);
-
     try {
         _ws = new WebSocket(BRIDGE_URL);
     } catch (err) {
@@ -83,44 +79,51 @@ function connect() {
 
     _ws.onopen = () => {
         _setStatus("Connected", `Bridge connected to Python at ${BRIDGE_URL}`);
-        // Announce ourselves to the Python server
-        _ws.send(JSON.stringify({ type: "hello", client: "photoshop-uxp", version: "0.1.0" }));
+        _ws.send(JSON.stringify(buildHello("photoshop-uxp", _reconnecting)));
+        _reconnecting = false;
     };
 
     _ws.onmessage = async (event) => {
         const raw = typeof event.data === "string" ? event.data : event.data.toString();
+        let msg;
+        try { msg = JSON.parse(raw); } catch (_e) { console.error("[dcc-mcp] Invalid JSON from server:", raw.slice(0, 200)); return; }
 
-        let request;
-        try {
-            request = JSON.parse(raw);
-        } catch (_e) {
-            console.error("[dcc-mcp] Invalid JSON from server:", raw.slice(0, 200));
+        // Protocol-level messages
+        if (msg.type) {
+            if (isHelloAck(msg)) {
+                if (msg.compatible === false) {
+                    _setStatus("Error", `Protocol mismatch: ${msg.error || "unspecified"}`);
+                } else {
+                    console.log("[dcc-mcp] Server acknowledged hello (protocol " + (msg.version || "?") + ")");
+                }
+                return;
+            }
+            if (isDisconnected(msg)) {
+                _setStatus("Disconnected", `Server: ${msg.reason || "unknown"}`);
+                return;
+            }
+            if (msg.type === "progress") {
+                const p = msg.progress || {};
+                console.log("[dcc-mcp] Progress id=" + msg.id + " " + (p.current || 0) + "/" + (p.total || 0) + (p.message ? " — " + p.message : ""));
+                return;
+            }
+            console.log("[dcc-mcp] Server message:", msg.type);
             return;
         }
 
-        // Handle non-RPC messages (e.g. server acknowledgement)
-        if (!request.method && request.type) {
-            console.log("[dcc-mcp] Server message:", request.type);
-            return;
-        }
-
+        // JSON-RPC request
         const { request: rpcReq, parseError } = parseRequest(raw);
-        if (parseError) {
-            _ws.send(JSON.stringify(parseError));
-            return;
-        }
-
+        if (parseError) { _ws.send(JSON.stringify(parseError)); return; }
         const response = await _dispatch(rpcReq);
         _ws.send(JSON.stringify(response));
     };
 
-    _ws.onerror = (err) => {
-        _setStatus("Error", String(err.message || err));
-    };
+    _ws.onerror = (err) => { _setStatus("Error", String(err.message || err)); };
 
     _ws.onclose = (event) => {
         _ws = null;
         if (!_stopped) {
+            _reconnecting = true;
             _setStatus("Disconnected", `Code ${event.code} — reconnecting in ${RECONNECT_DELAY_MS / 1000}s`);
             _scheduleReconnect();
         } else {
@@ -131,25 +134,13 @@ function connect() {
 
 function _scheduleReconnect() {
     if (_reconnectTimer) return;
-    _reconnectTimer = setTimeout(() => {
-        _reconnectTimer = null;
-        if (!_stopped) connect();
-    }, RECONNECT_DELAY_MS);
+    _reconnectTimer = setTimeout(() => { _reconnectTimer = null; if (!_stopped) connect(); }, RECONNECT_DELAY_MS);
 }
 
-/**
- * Disconnect and stop auto-reconnect.
- */
 function disconnect() {
     _stopped = true;
-    if (_reconnectTimer) {
-        clearTimeout(_reconnectTimer);
-        _reconnectTimer = null;
-    }
-    if (_ws) {
-        _ws.close();
-        _ws = null;
-    }
+    if (_reconnectTimer) { clearTimeout(_reconnectTimer); _reconnectTimer = null; }
+    if (_ws) { _ws.close(); _ws = null; }
     _setStatus("Disconnected", "Disconnected by user");
 }
 

--- a/bridge/uxp-plugin/src/utils/jsonrpc.js
+++ b/bridge/uxp-plugin/src/utils/jsonrpc.js
@@ -1,17 +1,69 @@
 /**
- * JSON-RPC 2.0 helpers.
+ * JSON-RPC 2.0 helpers + Photoshop bridge protocol v0.
  *
  * See: https://www.jsonrpc.org/specification
+ * See: docs/bridge-protocol.md
  */
 
 "use strict";
 
-// Standard JSON-RPC 2.0 error codes
+// ── Protocol identity ────────────────────────────────────────────────────────
+
+const PROTOCOL_NAME = "photoshop-bridge";
+const PROTOCOL_VERSION = "0.1.0";
+
+// ── Standard JSON-RPC 2.0 error codes ────────────────────────────────────────
+
 const RPC_PARSE_ERROR = -32700;
 const RPC_INVALID_REQUEST = -32600;
 const RPC_METHOD_NOT_FOUND = -32601;
 const RPC_INVALID_PARAMS = -32602;
 const RPC_INTERNAL_ERROR = -32603;
+
+// ── Photoshop bridge custom error codes ───────────────────────────────────────
+
+const CUSTOM_ERR_NO_ACTIVE_DOC     = -32001;
+const CUSTOM_ERR_LAYER_NOT_FOUND   = -32002;
+const CUSTOM_ERR_UNSUPPORTED_FORMAT = -32003;
+const CUSTOM_ERR_FILE_NOT_FOUND    = -32004;
+const CUSTOM_ERR_SCRIPT_ERROR      = -32005;
+const CUSTOM_ERR_TIMEOUT           = -32006;
+const CUSTOM_ERR_DISCONNECTED      = -32007;
+
+// ── Error code → hint mapping ─────────────────────────────────────────────────
+
+const ERROR_HINTS = {};
+ERROR_HINTS[RPC_PARSE_ERROR]         = "The JSON payload could not be parsed. Check for malformed escape sequences or trailing commas.";
+ERROR_HINTS[RPC_INVALID_REQUEST]     = "The request must be a JSON object with 'jsonrpc', 'id', 'method', and 'params' fields.";
+ERROR_HINTS[RPC_METHOD_NOT_FOUND]    = "Use ps.describeApi to list available methods.";
+ERROR_HINTS[RPC_INVALID_PARAMS]      = "Check the method's required parameters and their types.";
+ERROR_HINTS[RPC_INTERNAL_ERROR]      = "An unexpected error occurred inside the Photoshop handler. Check the plugin log for details.";
+ERROR_HINTS[CUSTOM_ERR_NO_ACTIVE_DOC]     = "Open or create a document before calling document/layer methods.";
+ERROR_HINTS[CUSTOM_ERR_LAYER_NOT_FOUND]   = "Use ps.listLayers to see the current layer tree.";
+ERROR_HINTS[CUSTOM_ERR_UNSUPPORTED_FORMAT] = "Supported formats: png, jpg, tiff, psd.";
+ERROR_HINTS[CUSTOM_ERR_FILE_NOT_FOUND]    = "Verify the path exists and Photoshop has permission to access it.";
+ERROR_HINTS[CUSTOM_ERR_SCRIPT_ERROR]      = "The JavaScript expression could not be evaluated. Check syntax and available APIs.";
+ERROR_HINTS[CUSTOM_ERR_TIMEOUT]           = "The operation took too long and was cancelled. Try a smaller operation or increase the timeout.";
+ERROR_HINTS[CUSTOM_ERR_DISCONNECTED]      = "The UXP plugin lost connection. It will auto-reconnect. Retry the call once reconnected.";
+
+// ── Message builders ──────────────────────────────────────────────────────────
+
+/**
+ * Build a hello message (UXP → Python).
+ * @param {string} [client="photoshop-uxp"]
+ * @param {boolean} [reconnect=false] - True if this is a reconnection.
+ * @returns {object}
+ */
+function buildHello(client, reconnect) {
+    const msg = {
+        type: "hello",
+        protocol: PROTOCOL_NAME,
+        version: PROTOCOL_VERSION,
+        client: client || "photoshop-uxp",
+    };
+    if (reconnect) msg.reconnect = true;
+    return msg;
+}
 
 /**
  * Build a JSON-RPC 2.0 success response.
@@ -24,22 +76,40 @@ function rpcSuccess(id, result) {
 }
 
 /**
- * Build a JSON-RPC 2.0 error response.
+ * Build a JSON-RPC 2.0 error response with optional hint.
  * @param {number|string|null} id - Request id (null for parse errors)
  * @param {number} code - Error code
  * @param {string} message - Error message
- * @param {*} [data] - Optional extra data
+ * @param {string} [hint] - Actionable suggestion. Auto-populated from known codes if omitted.
+ * @param {*} [data] - Optional extra diagnostic data
  * @returns {object}
  */
-function rpcError(id, code, message, data) {
+function rpcError(id, code, message, hint, data) {
     const error = { code, message };
+    const h = hint || ERROR_HINTS[code];
+    if (h) error.hint = h;
     if (data !== undefined) error.data = data;
     return { jsonrpc: "2.0", id, error };
 }
 
 /**
+ * Build a progress notification (UXP → Python).
+ * @param {number} id - The id of the original request
+ * @param {number} current - Current progress value
+ * @param {number} total - Total progress value
+ * @param {string} [message=""] - Human-readable description
+ * @param {string} [stage] - Named stage identifier
+ * @returns {object}
+ */
+function buildProgress(id, current, total, message, stage) {
+    const progress = { current, total };
+    if (message) progress.message = message;
+    if (stage) progress.stage = stage;
+    return { jsonrpc: "2.0", id, type: "progress", progress };
+}
+
+/**
  * Parse a raw WebSocket message into a JSON-RPC request object.
- * Returns null and sends a parse-error response if the message is invalid.
  * @param {string} raw - Raw message string
  * @returns {{ request: object|null, parseError: object|null }}
  */
@@ -48,29 +118,34 @@ function parseRequest(raw) {
     try {
         request = JSON.parse(raw);
     } catch (_e) {
-        return {
-            request: null,
-            parseError: rpcError(null, RPC_PARSE_ERROR, "Parse error"),
-        };
+        return { request: null, parseError: rpcError(null, RPC_PARSE_ERROR, "Parse error") };
     }
-
     if (!request || request.jsonrpc !== "2.0" || typeof request.method !== "string") {
-        return {
-            request: null,
-            parseError: rpcError(request.id ?? null, RPC_INVALID_REQUEST, "Invalid Request"),
-        };
+        const id = (request && request.id !== undefined) ? request.id : null;
+        return { request: null, parseError: rpcError(id, RPC_INVALID_REQUEST, "Invalid Request") };
     }
-
     return { request, parseError: null };
 }
 
+// ── Validators ────────────────────────────────────────────────────────────────
+
+function isHelloAck(msg) { return msg && msg.type === "hello_ack"; }
+function isDisconnected(msg) { return msg && msg.type === "disconnected"; }
+
+function checkVersion(version) {
+    try {
+        return parseInt(version.split(".")[0], 10) === 0;
+    } catch (_e) {
+        return false;
+    }
+}
+
 module.exports = {
-    RPC_PARSE_ERROR,
-    RPC_INVALID_REQUEST,
-    RPC_METHOD_NOT_FOUND,
-    RPC_INVALID_PARAMS,
-    RPC_INTERNAL_ERROR,
-    rpcSuccess,
-    rpcError,
-    parseRequest,
+    PROTOCOL_NAME, PROTOCOL_VERSION,
+    RPC_PARSE_ERROR, RPC_INVALID_REQUEST, RPC_METHOD_NOT_FOUND, RPC_INVALID_PARAMS, RPC_INTERNAL_ERROR,
+    CUSTOM_ERR_NO_ACTIVE_DOC, CUSTOM_ERR_LAYER_NOT_FOUND, CUSTOM_ERR_UNSUPPORTED_FORMAT,
+    CUSTOM_ERR_FILE_NOT_FOUND, CUSTOM_ERR_SCRIPT_ERROR, CUSTOM_ERR_TIMEOUT, CUSTOM_ERR_DISCONNECTED,
+    ERROR_HINTS,
+    buildHello, rpcSuccess, rpcError, buildProgress, parseRequest,
+    isHelloAck, isDisconnected, checkVersion,
 };

--- a/docs/bridge-protocol.md
+++ b/docs/bridge-protocol.md
@@ -1,0 +1,249 @@
+# Photoshop UXP WebSocket Bridge Protocol v0
+
+**Version**: 0.1.0
+**Transport**: WebSocket (Python server, UXP client)
+**Message format**: JSON-RPC 2.0 superset
+**Default endpoint**: `ws://localhost:9001`
+
+---
+
+## 1. Architecture
+
+```
+MCP Client ──HTTP──► Gateway (dcc-mcp-core) ──call()──► PhotoshopBridge (Python)
+                                                               │
+                                           WebSocket server localhost:9001
+                                                               │
+                                           Photoshop UXP plugin (WS client)
+                                                               │
+                                           Photoshop UXP API
+```
+
+Python starts a WebSocket server. The UXP plugin connects as a client (UXP does not support WebSocket server mode). Python sends JSON-RPC 2.0 requests; UXP executes them against the Photoshop API and returns responses.
+
+---
+
+## 2. Connection Lifecycle
+
+### 2.1 State Machine
+
+```
+ ┌──────────┐  server starts   ┌──────────────┐  UXP connects    ┌───────────────┐
+ │  CLOSED  │ ───────────────► │  LISTENING   │ ────────────────► │   CONNECTED   │
+ └──────────┘                  └──────────────┘                   └───────────────┘
+       ▲                              │                                  │    │
+       │                              │ UXP fails to connect             │    │
+       │ server.stop()                ▼                                  │    │ UXP disconnects
+       │                     ┌──────────────┐                            │    ▼
+       └─────────────────────│    ERROR     │◄───────────────────────────┘
+                             └──────────────┘                    ┌──────────────┐
+                                                                 │ DISCONNECTED │
+                                                                 └──────────────┘
+                                                                        │
+                                                                        │ auto-reconnect (3s)
+                                                                        ▼
+                                                                 ┌───────────────┐
+                                                                 │ RECONNECTING  │──► CONNECTED
+                                                                 └───────────────┘
+```
+
+### 2.2 Lifecycle Events
+
+| Event | Direction | Trigger | Payload |
+|-------|-----------|---------|---------|
+| `hello` | UXP → Python | WebSocket onopen | `{type, protocol, version, client}` |
+| `hello_ack` | Python → UXP | After hello received | `{type, protocol, version}` |
+| `disconnected` | Python → UXP | UXP disconnects or server stops | `{type: "disconnected", reason}` |
+| `reconnecting` | UXP → Python | On reconnect attempt | `{type: "hello", reconnect: true, ...}` |
+| `progress` | UXP → Python | Long-running operation progress | `{jsonrpc, id, type: "progress", progress}` |
+| `connected` | UXP → Python | First hello after connection | `{type: "hello", ...}` |
+
+### 2.3 Hello Handshake
+
+**UXP → Python** (on WebSocket open):
+```json
+{
+    "type": "hello",
+    "protocol": "photoshop-bridge",
+    "version": "0.1.0",
+    "client": "photoshop-uxp",
+    "reconnect": false
+}
+```
+
+**Python → UXP** (after receiving hello):
+```json
+{
+    "type": "hello_ack",
+    "protocol": "photoshop-bridge",
+    "version": "0.1.0"
+}
+```
+
+### 2.4 Disconnection
+
+When the UXP client disconnects:
+- Python fails all pending RPC calls with `BridgeConnectionError("UXP plugin disconnected")`
+- Python sets `_connected = false`
+- UXP auto-reconnects after 3 seconds (unless `_stopped = true`)
+
+When Python shuts down the server:
+- Python closes the WebSocket connection
+- UXP `onclose` fires; UXP enters reconnecting state
+
+---
+
+## 3. RPC Envelope
+
+### 3.1 Request (Python → UXP)
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "ps.getDocumentInfo",
+    "params": {}
+}
+```
+
+### 3.2 Success Response (UXP → Python)
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {}
+}
+```
+
+### 3.3 Error Response (UXP → Python)
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "error": {
+        "code": -32601,
+        "message": "Method not found: ps.unknownMethod",
+        "hint": "Use ps.describeApi to list available methods",
+        "data": {
+            "method": "ps.unknownMethod"
+        }
+    }
+}
+```
+
+### 3.4 Progress Notification (UXP → Python)
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 3,
+    "type": "progress",
+    "progress": {
+        "current": 50,
+        "total": 100,
+        "message": "Exporting document to /tmp/export.png...",
+        "stage": "export"
+    }
+}
+```
+
+---
+
+## 4. Error Codes
+
+### 4.1 Standard JSON-RPC 2.0 Codes
+
+| Code | Name | Description |
+|------|------|-------------|
+| `-32700` | Parse error | Invalid JSON received |
+| `-32600` | Invalid Request | Not a valid JSON-RPC request |
+| `-32601` | Method not found | Method does not exist |
+| `-32602` | Invalid params | Missing or invalid parameters |
+| `-32603` | Internal error | Unexpected handler error |
+
+### 4.2 Photoshop Bridge Custom Codes
+
+| Code | Name | Description |
+|------|------|-------------|
+| `-32001` | No Active Document | No document open in Photoshop |
+| `-32002` | Layer Not Found | Named layer does not exist |
+| `-32003` | Unsupported Format | Export format not supported |
+| `-32004` | File Not Found | Path does not exist on disk |
+| `-32005` | Script Error | UXP script execution failed |
+| `-32006` | Timeout | Operation exceeded timeout |
+| `-32007` | Disconnected | UXP connection lost mid-operation |
+
+---
+
+## 5. Method Namespace
+
+### 5.1 Document Operations
+
+| Method | Parameters | Returns |
+|--------|------------|---------|
+| `ps.getDocumentInfo` | _(none)_ | Document metadata object |
+| `ps.listDocuments` | _(none)_ | Array of document metadata |
+| `ps.createDocument` | `name?`, `width?`, `height?`, `resolution?`, `color_mode?`, `bit_depth?` | Created document metadata |
+| `ps.openDocument` | `path` (required) | Opened document metadata |
+| `ps.saveDocument` | _(none)_ | `{saved, path}` |
+| `ps.closeDocument` | `save?` (boolean, default false) | `{closed}` |
+| `ps.exportDocument` | `path` (required), `format?` (png/jpg/tiff/psd), `quality?` (jpg, 0-100) | `{exported, path, format}` |
+
+### 5.2 Layer Operations
+
+| Method | Parameters | Returns |
+|--------|------------|---------|
+| `ps.listLayers` | `include_hidden?` (boolean, default true) | Layer tree array |
+| `ps.createLayer` | `name?`, `type?` (pixel/group) | `{id, name, type}` |
+| `ps.deleteLayer` | `name` (required) | `{deleted, name}` |
+| `ps.setLayerVisibility` | `name`, `visible` (both required) | `{name, visible}` |
+| `ps.renameLayer` | `name`, `new_name` (both required) | `{old_name, name}` |
+| `ps.setLayerOpacity` | `name`, `opacity` (both required, 0-100) | `{name, opacity}` |
+| `ps.duplicateLayer` | `name` (required), `new_name?` | `{id, name}` |
+| `ps.setLayerBlendMode` | `name`, `blend_mode` (both required) | `{name, blend_mode}` |
+| `ps.fillLayer` | `name`, `color` (both required) | `{filled, name, color}` |
+
+### 5.3 Image Operations
+
+| Method | Parameters | Returns |
+|--------|------------|---------|
+| `ps.resizeCanvas` | `width`, `height` (both required) | `{width, height}` |
+| `ps.resizeImage` | `width`, `height` (both required) | `{width, height}` |
+| `ps.flattenImage` | _(none)_ | `{flattened}` |
+| `ps.mergeVisibleLayers` | _(none)_ | `{merged, layer_name}` |
+
+### 5.4 Text Operations
+
+| Method | Parameters | Returns |
+|--------|------------|---------|
+| `ps.createTextLayer` | `content` (required), `name?` | `{id, name, content}` |
+| `ps.updateTextLayer` | `name`, `content` (both required) | `{name, content}` |
+| `ps.getTextLayerInfo` | `name` (required) | `{name, content, font, size, color, alignment, bold, italic}` |
+
+### 5.5 Script / Meta Operations
+
+| Method | Parameters | Returns |
+|--------|------------|---------|
+| `ps.executeScript` | `code` (required) | Script return value |
+| `ps.executeAction` | `action`, `action_set` (both required) | `{executed, action, action_set}` |
+| `ps.describeApi` | _(none)_ | `{protocol, version, methods: [...]}` |
+| `ps.invoke` | `path`, `args?`, `kwargs?`, `modal?` | Reflected API result |
+| `ps.batchPlay` | `commands`, `options?`, `modal?` | batchPlay result |
+
+---
+
+## 6. Protocol Version Compatibility
+
+| Version | Changes |
+|---------|---------|
+| `0.1.0` | Initial protocol: JSON-RPC 2.0 + hello handshake + progress notifications + extended error envelope |
+
+Version negotiation: The UXP plugin declares its protocol version in the `hello` message. If the Python server requires a different version, it responds with `hello_ack` containing `compatible: false` and an `error` field explaining the mismatch.
+
+---
+
+## 7. Contract Tests
+
+See `tests/test_protocol.py` and `tests/conftest.py` (mock UXP peer).

--- a/src/dcc_mcp_photoshop/bridge.py
+++ b/src/dcc_mcp_photoshop/bridge.py
@@ -20,8 +20,8 @@ Why inverted?
   UXP only supports WebSocket CLIENT, not server.
   See: https://forums.creativeclouddeveloper.com/t/7423
 
-Protocol
---------
+Protocol (v0.1.0)
+------------------
   Python → UXP  (request):
     {"jsonrpc":"2.0","id":1,"method":"ps.getDocumentInfo","params":{}}
 
@@ -29,10 +29,21 @@ Protocol
     {"jsonrpc":"2.0","id":1,"result":{"name":"Untitled-1.psd",...}}
 
   UXP → Python  (error):
-    {"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"..."}}
+    {"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"...","hint":"..."}}
+
+  UXP → Python  (progress):
+    {"jsonrpc":"2.0","id":1,"type":"progress","progress":{"current":50,"total":100}}
 
   UXP → Python  (hello, on connect):
-    {"type":"hello","client":"photoshop-uxp","version":"0.1.0"}
+    {"type":"hello","protocol":"photoshop-bridge","version":"0.1.0","client":"photoshop-uxp"}
+
+  Python → UXP  (hello_ack):
+    {"type":"hello_ack","protocol":"photoshop-bridge","version":"0.1.0"}
+
+  Python → UXP  (disconnected):
+    {"type":"disconnected","reason":"Server stopped"}
+
+See docs/bridge-protocol.md for the full specification.
 """
 
 from __future__ import annotations
@@ -46,6 +57,15 @@ from concurrent.futures import Future
 from concurrent.futures import TimeoutError as FutureTimeoutError
 from pathlib import Path
 from typing import Any, Dict, Optional
+
+from dcc_mcp_photoshop.protocol import (
+    PROTOCOL_NAME,
+    PROTOCOL_VERSION,
+    build_hello_ack,
+    build_disconnected,
+    is_hello,
+    is_progress,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -112,12 +132,14 @@ class BridgeRpcError(RuntimeError):
 
     Attributes:
         code: JSON-RPC error code.
-        data: Optional extra data.
+        hint: Actionable suggestion from the UXP side.
+        data: Optional extra diagnostic data.
     """
 
-    def __init__(self, message: str, code: int = -32603, data: Any = None) -> None:
+    def __init__(self, message: str, code: int = -32603, hint: str = "", data: Any = None) -> None:
         super().__init__(message)
         self.code = code
+        self.hint = hint
         self.data = data
 
 
@@ -285,12 +307,30 @@ class PhotoshopBridge:
                     logger.warning("PhotoshopBridge: invalid JSON from UXP: %r", raw[:200])
                     continue
 
-                # Handle non-RPC hello message
-                if msg.get("type") == "hello":
+                # Handle hello handshake
+                if is_hello(msg):
+                    reconnect = " (reconnect)" if msg.get("reconnect") else ""
                     logger.info(
-                        "UXP plugin hello: %s v%s",
+                        "UXP plugin hello: %s v%s%s",
                         msg.get("client"),
                         msg.get("version"),
+                        reconnect,
+                    )
+                    try:
+                        await websocket.send(json.dumps(build_hello_ack()))
+                    except Exception:
+                        pass
+                    continue
+
+                # Handle progress notification — log but do NOT resolve pending future
+                if is_progress(msg):
+                    p = msg.get("progress", {})
+                    logger.debug(
+                        "Progress id=%r %d/%d%s",
+                        msg.get("id"),
+                        p.get("current", 0),
+                        p.get("total", 0),
+                        f" — {p['message']}" if p.get("message") else "",
                     )
                     continue
 
@@ -313,6 +353,7 @@ class PhotoshopBridge:
                     exc = BridgeRpcError(
                         err_info.get("message", "Unknown RPC error"),
                         code=err_info.get("code", -32603),
+                        hint=err_info.get("hint", ""),
                         data=err_info.get("data"),
                     )
                     self._set_future_exception(future, exc)
@@ -349,6 +390,11 @@ class PhotoshopBridge:
         if self._loop is not None:
 
             async def _close():
+                if self._uxp_ws:
+                    try:
+                        await self._uxp_ws.send(json.dumps(build_disconnected()))
+                    except Exception:
+                        pass
                 if self._server:
                     self._server.close()
                     await self._server.wait_closed()

--- a/src/dcc_mcp_photoshop/bridge.py
+++ b/src/dcc_mcp_photoshop/bridge.py
@@ -59,10 +59,8 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from dcc_mcp_photoshop.protocol import (
-    PROTOCOL_NAME,
-    PROTOCOL_VERSION,
-    build_hello_ack,
     build_disconnected,
+    build_hello_ack,
     is_hello,
     is_progress,
 )

--- a/src/dcc_mcp_photoshop/protocol.py
+++ b/src/dcc_mcp_photoshop/protocol.py
@@ -1,0 +1,205 @@
+"""Photoshop UXP WebSocket bridge protocol v0 — message builders and validators.
+
+Defines the wire format for Python ↔ UXP communication.
+See docs/bridge-protocol.md for the full specification.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional
+
+# ── Protocol identity ──────────────────────────────────────────────────────
+
+PROTOCOL_NAME = "photoshop-bridge"
+PROTOCOL_VERSION = "0.1.0"
+PROTOCOL_TAG = f"{PROTOCOL_NAME}/{PROTOCOL_VERSION}"
+
+# ── Message types ──────────────────────────────────────────────────────────
+
+TYPE_HELLO = "hello"
+TYPE_HELLO_ACK = "hello_ack"
+TYPE_DISCONNECTED = "disconnected"
+TYPE_PROGRESS = "progress"
+
+# ── Standard JSON-RPC 2.0 error codes ──────────────────────────────────────
+
+RPC_PARSE_ERROR = -32700
+RPC_INVALID_REQUEST = -32600
+RPC_METHOD_NOT_FOUND = -32601
+RPC_INVALID_PARAMS = -32602
+RPC_INTERNAL_ERROR = -32603
+
+# ── Photoshop bridge custom error codes ────────────────────────────────────
+
+CUSTOM_ERR_NO_ACTIVE_DOC = -32001
+CUSTOM_ERR_LAYER_NOT_FOUND = -32002
+CUSTOM_ERR_UNSUPPORTED_FORMAT = -32003
+CUSTOM_ERR_FILE_NOT_FOUND = -32004
+CUSTOM_ERR_SCRIPT_ERROR = -32005
+CUSTOM_ERR_TIMEOUT = -32006
+CUSTOM_ERR_DISCONNECTED = -32007
+
+# ── Error code → hint mapping ──────────────────────────────────────────────
+
+_ERROR_HINTS: Dict[int, str] = {
+    RPC_PARSE_ERROR: "The JSON payload could not be parsed. Check for malformed escape sequences or trailing commas.",
+    RPC_INVALID_REQUEST: "The request must be a JSON object with 'jsonrpc', 'id', 'method', and 'params' fields.",
+    RPC_METHOD_NOT_FOUND: "Use ps.describeApi to list available methods.",
+    RPC_INVALID_PARAMS: "Check the method's required parameters and their types.",
+    RPC_INTERNAL_ERROR: "An unexpected error occurred inside the Photoshop handler. Check the plugin log for details.",
+    CUSTOM_ERR_NO_ACTIVE_DOC: "Open or create a document before calling document/layer methods.",
+    CUSTOM_ERR_LAYER_NOT_FOUND: "Use ps.listLayers to see the current layer tree.",
+    CUSTOM_ERR_UNSUPPORTED_FORMAT: "Supported formats: png, jpg, tiff, psd.",
+    CUSTOM_ERR_FILE_NOT_FOUND: "Verify the path exists and Photoshop has permission to access it.",
+    CUSTOM_ERR_SCRIPT_ERROR: "The JavaScript expression could not be evaluated. Check syntax and available APIs.",
+    CUSTOM_ERR_TIMEOUT: "The operation took too long and was cancelled. Try a smaller operation or increase the timeout.",
+    CUSTOM_ERR_DISCONNECTED: "The UXP plugin lost connection. It will auto-reconnect. Retry the call once reconnected.",
+}
+
+# ── Message builders ───────────────────────────────────────────────────────
+
+
+def build_hello(client: str = "photoshop-uxp", reconnect: bool = False) -> Dict[str, Any]:
+    msg: Dict[str, Any] = {
+        "type": TYPE_HELLO,
+        "protocol": PROTOCOL_NAME,
+        "version": PROTOCOL_VERSION,
+        "client": client,
+    }
+    if reconnect:
+        msg["reconnect"] = True
+    return msg
+
+
+def build_hello_ack() -> Dict[str, Any]:
+    return {
+        "type": TYPE_HELLO_ACK,
+        "protocol": PROTOCOL_NAME,
+        "version": PROTOCOL_VERSION,
+    }
+
+
+def build_hello_ack_error(reason: str) -> Dict[str, Any]:
+    return {
+        "type": TYPE_HELLO_ACK,
+        "protocol": PROTOCOL_NAME,
+        "version": PROTOCOL_VERSION,
+        "compatible": False,
+        "error": reason,
+    }
+
+
+def build_disconnected(reason: str = "Server stopped") -> Dict[str, Any]:
+    return {
+        "type": TYPE_DISCONNECTED,
+        "reason": reason,
+    }
+
+
+def build_request(req_id: int, method: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "method": method,
+        "params": params or {},
+    }
+
+
+def build_success(req_id: int, result: Any) -> Dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "result": result,
+    }
+
+
+def build_error(
+    req_id: Optional[int],
+    code: int,
+    message: str,
+    hint: Optional[str] = None,
+    data: Any = None,
+) -> Dict[str, Any]:
+    error: Dict[str, Any] = {"code": code, "message": message}
+    if hint is None:
+        hint = _ERROR_HINTS.get(code)
+    if hint:
+        error["hint"] = hint
+    if data is not None:
+        error["data"] = data
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "error": error,
+    }
+
+
+def build_progress(
+    req_id: int,
+    current: int,
+    total: int,
+    message: str = "",
+    stage: Optional[str] = None,
+) -> Dict[str, Any]:
+    progress: Dict[str, Any] = {"current": current, "total": total}
+    if message:
+        progress["message"] = message
+    if stage:
+        progress["stage"] = stage
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "type": TYPE_PROGRESS,
+        "progress": progress,
+    }
+
+
+# ── Validators ─────────────────────────────────────────────────────────────
+
+
+def is_hello(msg: Dict[str, Any]) -> bool:
+    return msg.get("type") == TYPE_HELLO and msg.get("protocol") == PROTOCOL_NAME
+
+
+def is_rpc_request(msg: Dict[str, Any]) -> bool:
+    return (
+        msg.get("jsonrpc") == "2.0"
+        and isinstance(msg.get("id"), (int, float))
+        and isinstance(msg.get("method"), str)
+        and isinstance(msg.get("params"), dict)
+    )
+
+
+def is_rpc_response(msg: Dict[str, Any]) -> bool:
+    if msg.get("jsonrpc") != "2.0":
+        return False
+    if not isinstance(msg.get("id"), (int, float)):
+        return False
+    return "result" in msg or "error" in msg
+
+
+def is_progress(msg: Dict[str, Any]) -> bool:
+    return (
+        msg.get("jsonrpc") == "2.0"
+        and msg.get("type") == TYPE_PROGRESS
+        and isinstance(msg.get("id"), (int, float))
+        and isinstance(msg.get("progress"), dict)
+    )
+
+
+def check_version(version: str) -> bool:
+    try:
+        parts = version.split(".")
+        major = int(parts[0])
+        return major == 0
+    except (ValueError, IndexError):
+        return False
+
+
+def parse_message(raw: str) -> Optional[Dict[str, Any]]:
+    try:
+        msg = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return msg if isinstance(msg, dict) else None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,12 +205,16 @@ def connected_bridge():
     async def _run_mock_uxp():
         async with websockets.connect(f"ws://localhost:{port}") as ws:
             # Send hello (protocol v0)
-            await ws.send(json.dumps({
-                "type": "hello",
-                "protocol": "photoshop-bridge",
-                "version": "0.1.0",
-                "client": "photoshop-uxp-mock",
-            }))
+            await ws.send(
+                json.dumps(
+                    {
+                        "type": "hello",
+                        "protocol": "photoshop-bridge",
+                        "version": "0.1.0",
+                        "client": "photoshop-uxp-mock",
+                    }
+                )
+            )
             uxp_started.set()
             try:
                 async for raw in ws:
@@ -225,23 +229,33 @@ def connected_bridge():
                         result = await _handle_rpc(req)
                         await ws.send(json.dumps({"jsonrpc": "2.0", "id": req_id, "result": result}))
                     except ValueError as exc:
-                        await ws.send(json.dumps({
-                            "jsonrpc": "2.0", "id": req_id,
-                            "error": {
-                                "code": -32601,
-                                "message": str(exc),
-                                "hint": "Use ps.describeApi to list available methods",
-                            },
-                        }))
+                        await ws.send(
+                            json.dumps(
+                                {
+                                    "jsonrpc": "2.0",
+                                    "id": req_id,
+                                    "error": {
+                                        "code": -32601,
+                                        "message": str(exc),
+                                        "hint": "Use ps.describeApi to list available methods",
+                                    },
+                                }
+                            )
+                        )
                     except Exception as exc:  # noqa: BLE001
-                        await ws.send(json.dumps({
-                            "jsonrpc": "2.0", "id": req_id,
-                            "error": {
-                                "code": -32603,
-                                "message": str(exc),
-                                "hint": "An unexpected error occurred inside the Photoshop handler.",
-                            },
-                        }))
+                        await ws.send(
+                            json.dumps(
+                                {
+                                    "jsonrpc": "2.0",
+                                    "id": req_id,
+                                    "error": {
+                                        "code": -32603,
+                                        "message": str(exc),
+                                        "hint": "An unexpected error occurred inside the Photoshop handler.",
+                                    },
+                                }
+                            )
+                        )
             except Exception:
                 pass
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,7 +165,6 @@ def connected_bridge():
     bridge = PhotoshopBridge(host="localhost", port=0, timeout=10.0)
 
     _actual_port: list = []
-    _original_serve = bridge._serve
 
     async def _patched_serve(ready_event, uxp_event, exc_out):
         import websockets as ws  # noqa: PLC0415
@@ -205,7 +204,13 @@ def connected_bridge():
 
     async def _run_mock_uxp():
         async with websockets.connect(f"ws://localhost:{port}") as ws:
-            await ws.send(json.dumps({"type": "hello", "client": "photoshop-uxp-mock", "version": "0.1.0"}))
+            # Send hello (protocol v0)
+            await ws.send(json.dumps({
+                "type": "hello",
+                "protocol": "photoshop-bridge",
+                "version": "0.1.0",
+                "client": "photoshop-uxp-mock",
+            }))
             uxp_started.set()
             try:
                 async for raw in ws:
@@ -220,13 +225,23 @@ def connected_bridge():
                         result = await _handle_rpc(req)
                         await ws.send(json.dumps({"jsonrpc": "2.0", "id": req_id, "result": result}))
                     except ValueError as exc:
-                        await ws.send(
-                            json.dumps({"jsonrpc": "2.0", "id": req_id, "error": {"code": -32601, "message": str(exc)}})
-                        )
+                        await ws.send(json.dumps({
+                            "jsonrpc": "2.0", "id": req_id,
+                            "error": {
+                                "code": -32601,
+                                "message": str(exc),
+                                "hint": "Use ps.describeApi to list available methods",
+                            },
+                        }))
                     except Exception as exc:  # noqa: BLE001
-                        await ws.send(
-                            json.dumps({"jsonrpc": "2.0", "id": req_id, "error": {"code": -32603, "message": str(exc)}})
-                        )
+                        await ws.send(json.dumps({
+                            "jsonrpc": "2.0", "id": req_id,
+                            "error": {
+                                "code": -32603,
+                                "message": str(exc),
+                                "hint": "An unexpected error occurred inside the Photoshop handler.",
+                            },
+                        }))
             except Exception:
                 pass
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,0 +1,466 @@
+"""Contract tests for the Photoshop bridge protocol v0.
+
+These tests verify the protocol wire format, lifecycle events,
+error envelopes, and edge-case behavior without Photoshop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+
+import pytest
+import websockets
+
+
+# ---------------------------------------------------------------------------
+# Message builder unit tests (no server needed)
+# ---------------------------------------------------------------------------
+
+
+class TestMessageBuilders:
+    def test_build_hello(self):
+        from dcc_mcp_photoshop.protocol import build_hello
+
+        msg = build_hello()
+        assert msg["type"] == "hello"
+        assert msg["protocol"] == "photoshop-bridge"
+        assert msg["version"] == "0.1.0"
+        assert msg["client"] == "photoshop-uxp"
+        assert "reconnect" not in msg
+
+    def test_build_hello_reconnect(self):
+        from dcc_mcp_photoshop.protocol import build_hello
+
+        msg = build_hello(reconnect=True)
+        assert msg["reconnect"] is True
+
+    def test_build_hello_ack(self):
+        from dcc_mcp_photoshop.protocol import build_hello_ack
+
+        msg = build_hello_ack()
+        assert msg["type"] == "hello_ack"
+        assert msg["protocol"] == "photoshop-bridge"
+        assert msg["version"] == "0.1.0"
+
+    def test_build_hello_ack_error(self):
+        from dcc_mcp_photoshop.protocol import build_hello_ack_error
+
+        msg = build_hello_ack_error("Version 2.0.0 not supported")
+        assert msg["compatible"] is False
+        assert "2.0.0" in msg["error"]
+
+    def test_build_request(self):
+        from dcc_mcp_photoshop.protocol import build_request
+
+        msg = build_request(1, "ps.getDocumentInfo")
+        assert msg["jsonrpc"] == "2.0"
+        assert msg["id"] == 1
+        assert msg["method"] == "ps.getDocumentInfo"
+        assert msg["params"] == {}
+
+    def test_build_request_with_params(self):
+        from dcc_mcp_photoshop.protocol import build_request
+
+        msg = build_request(2, "ps.createLayer", {"name": "test", "type": "pixel"})
+        assert msg["params"] == {"name": "test", "type": "pixel"}
+
+    def test_build_success(self):
+        from dcc_mcp_photoshop.protocol import build_success
+
+        msg = build_success(1, {"exported": True})
+        assert msg["jsonrpc"] == "2.0"
+        assert msg["id"] == 1
+        assert msg["result"] == {"exported": True}
+
+    def test_build_error_known_code_auto_hint(self):
+        from dcc_mcp_photoshop.protocol import build_error, RPC_METHOD_NOT_FOUND
+
+        msg = build_error(1, RPC_METHOD_NOT_FOUND, "Method not found: ps.unknown")
+        assert msg["error"]["code"] == RPC_METHOD_NOT_FOUND
+        assert "hint" in msg["error"]
+        assert "describeApi" in msg["error"]["hint"]
+
+    def test_build_error_explicit_hint(self):
+        from dcc_mcp_photoshop.protocol import build_error
+
+        msg = build_error(1, -32099, "Custom error", hint="Do this instead")
+        assert msg["error"]["hint"] == "Do this instead"
+
+    def test_build_error_with_data(self):
+        from dcc_mcp_photoshop.protocol import build_error
+
+        msg = build_error(1, -32602, "Invalid params", data={"missing": ["name"]})
+        assert msg["error"]["data"] == {"missing": ["name"]}
+
+    def test_build_error_null_id(self):
+        from dcc_mcp_photoshop.protocol import build_error, RPC_PARSE_ERROR
+
+        msg = build_error(None, RPC_PARSE_ERROR, "Parse error")
+        assert msg["id"] is None
+
+    def test_build_progress(self):
+        from dcc_mcp_photoshop.protocol import build_progress
+
+        msg = build_progress(5, 50, 100, "Exporting...", "export")
+        assert msg["jsonrpc"] == "2.0"
+        assert msg["id"] == 5
+        assert msg["type"] == "progress"
+        assert msg["progress"] == {"current": 50, "total": 100, "message": "Exporting...", "stage": "export"}
+
+    def test_build_progress_minimal(self):
+        from dcc_mcp_photoshop.protocol import build_progress
+
+        msg = build_progress(3, 0, 100)
+        assert msg["progress"] == {"current": 0, "total": 100}
+
+    def test_build_disconnected(self):
+        from dcc_mcp_photoshop.protocol import build_disconnected
+
+        msg = build_disconnected("Server stopped")
+        assert msg["type"] == "disconnected"
+        assert msg["reason"] == "Server stopped"
+
+
+# ---------------------------------------------------------------------------
+# Validators
+# ---------------------------------------------------------------------------
+
+
+class TestValidators:
+    def test_is_hello_valid(self):
+        from dcc_mcp_photoshop.protocol import is_hello
+
+        assert is_hello({"type": "hello", "protocol": "photoshop-bridge", "version": "0.1.0"})
+        assert not is_hello({"type": "hello", "protocol": "wrong"})
+        assert not is_hello({"type": "not-hello"})
+        assert not is_hello({})
+
+    def test_is_rpc_request_valid(self):
+        from dcc_mcp_photoshop.protocol import is_rpc_request
+
+        assert is_rpc_request({"jsonrpc": "2.0", "id": 1, "method": "ps.test", "params": {}})
+        assert not is_rpc_request({"jsonrpc": "1.0", "id": 1, "method": "ps.test", "params": {}})
+        assert not is_rpc_request({"jsonrpc": "2.0", "id": "string", "method": "ps.test", "params": {}})
+        assert not is_rpc_request({"jsonrpc": "2.0"})
+
+    def test_is_rpc_response_valid(self):
+        from dcc_mcp_photoshop.protocol import is_rpc_response
+
+        assert is_rpc_response({"jsonrpc": "2.0", "id": 1, "result": {}})
+        assert is_rpc_response({"jsonrpc": "2.0", "id": 1, "error": {"code": -32601, "message": "x"}})
+        assert not is_rpc_response({"jsonrpc": "2.0", "id": 1})
+        assert not is_rpc_response({"result": {}})
+
+    def test_is_progress_valid(self):
+        from dcc_mcp_photoshop.protocol import is_progress
+
+        assert is_progress({"jsonrpc": "2.0", "id": 1, "type": "progress", "progress": {"current": 0, "total": 10}})
+        assert not is_progress({"jsonrpc": "2.0", "id": 1, "type": "other", "progress": {}})
+        assert not is_progress({"type": "progress"})
+
+    def test_check_version_compatible(self):
+        from dcc_mcp_photoshop.protocol import check_version
+
+        assert check_version("0.1.0")
+        assert check_version("0.99.99")
+        assert not check_version("1.0.0")
+        assert not check_version("2.0.0")
+        assert not check_version("not-a-version")
+
+    def test_parse_message(self):
+        from dcc_mcp_photoshop.protocol import parse_message
+
+        assert parse_message('{"key":"value"}') == {"key": "value"}
+        assert parse_message("invalid json") is None
+        assert parse_message("42") is None
+        assert parse_message('["array"]') is None
+
+
+# ---------------------------------------------------------------------------
+# Hello handshake (integration — needs bridge server)
+# ---------------------------------------------------------------------------
+
+
+class TestHelloHandshake:
+    def test_hello_receives_ack(self, connected_bridge):
+        assert connected_bridge.is_connected()
+
+    def test_hello_ack_is_valid(self):
+        from dcc_mcp_photoshop.bridge import PhotoshopBridge
+
+        bridge = PhotoshopBridge(host="localhost", port=0, timeout=5.0)
+        _actual_port: list = []
+
+        async def _patched_serve(ready_event, uxp_event, exc_out):
+            import websockets as ws
+
+            try:
+                bridge._server = await ws.serve(
+                    lambda websocket: bridge._handle_uxp(websocket, uxp_event),
+                    "localhost",
+                    0,
+                )
+                port = bridge._server.sockets[0].getsockname()[1]
+                _actual_port.append(port)
+                bridge._port = port
+            except Exception as exc:
+                exc_out.append(exc)
+            finally:
+                ready_event.set()
+
+        bridge._serve = _patched_serve
+        bridge.connect(wait_for_uxp=False)
+        time.sleep(0.1)
+        if not _actual_port:
+            bridge.disconnect()
+            pytest.skip("Could not start bridge server")
+        port = _actual_port[0]
+
+        async def _raw_client():
+            ws = await websockets.connect(f"ws://localhost:{port}")
+            await ws.send(json.dumps({
+                "type": "hello", "protocol": "photoshop-bridge",
+                "version": "0.1.0", "client": "test-harness",
+            }))
+            raw = await ws.recv()
+            ack = json.loads(raw)
+            await ws.close()
+            return ack
+
+        ack = asyncio.new_event_loop().run_until_complete(_raw_client())
+        assert ack["type"] == "hello_ack"
+        assert ack["protocol"] == "photoshop-bridge"
+        assert ack["version"] == "0.1.0"
+        bridge.disconnect()
+
+    def test_reconnect_hello(self, connected_bridge):
+        assert connected_bridge._uxp_connect_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# Request / response envelope
+# ---------------------------------------------------------------------------
+
+
+class TestRequestEnvelope:
+    def test_request_id_is_monotonic(self, connected_bridge):
+        id1 = connected_bridge._request_id
+        connected_bridge.call("ps.getDocumentInfo")
+        id2 = connected_bridge._request_id
+        assert id2 > id1
+
+    def test_response_id_matches_request(self, connected_bridge):
+        info = connected_bridge.call("ps.getDocumentInfo")
+        assert info["name"] == "Untitled-1.psd"
+
+    def test_success_response_has_result_not_error(self, connected_bridge):
+        result = connected_bridge.call("ps.getDocumentInfo")
+        assert isinstance(result, dict)
+        assert "name" in result
+
+
+# ---------------------------------------------------------------------------
+# Error envelope
+# ---------------------------------------------------------------------------
+
+
+class TestErrorEnvelope:
+    def test_method_not_found_error_shape(self, connected_bridge):
+        from dcc_mcp_photoshop.bridge import BridgeRpcError
+
+        with pytest.raises(BridgeRpcError) as exc_info:
+            connected_bridge.call("ps.nonExistentMethod")
+        assert exc_info.value.code == -32601
+        assert "ps.nonExistentMethod" in str(exc_info.value)
+        assert exc_info.value.hint
+
+    def test_error_has_code_message(self, connected_bridge):
+        from dcc_mcp_photoshop.bridge import BridgeRpcError
+
+        try:
+            connected_bridge.call("ps.nonExistentMethod")
+        except BridgeRpcError as e:
+            assert isinstance(e.code, int)
+            assert e.code == -32601
+            assert isinstance(str(e), str)
+            assert len(str(e)) > 0
+
+    def test_bridge_rpc_error_carries_hint(self, connected_bridge):
+        from dcc_mcp_photoshop.bridge import BridgeRpcError
+
+        try:
+            connected_bridge.call("ps.nonExistentMethod")
+        except BridgeRpcError as e:
+            assert e.hint, f"Expected non-empty hint, got {e.hint!r}"
+            assert "describeapi" in e.hint.lower()
+
+
+# ---------------------------------------------------------------------------
+# Unknown method / malformed payload behavior
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownAndMalformed:
+    def test_unknown_method_returns_32601(self, connected_bridge):
+        from dcc_mcp_photoshop.bridge import BridgeRpcError
+
+        with pytest.raises(BridgeRpcError) as exc_info:
+            connected_bridge.call("ps.doesNotExist")
+        assert exc_info.value.code == -32601
+
+    def test_multiple_parallel_calls_correctly_routed(self, connected_bridge):
+        info = connected_bridge.call("ps.getDocumentInfo")
+        layers = connected_bridge.call("ps.listLayers", include_hidden=False)
+        docs = connected_bridge.call("ps.listDocuments")
+        assert info["name"] == "Untitled-1.psd"
+        assert len(layers) == 2
+        assert len(docs) == 1
+
+
+# ---------------------------------------------------------------------------
+# Timeout behavior
+# ---------------------------------------------------------------------------
+
+
+class TestTimeoutBehavior:
+    def test_call_timeout_raises(self, connected_bridge):
+        from concurrent.futures import Future
+        from concurrent.futures import TimeoutError as FutureTimeoutError
+
+        from dcc_mcp_photoshop.bridge import BridgeTimeoutError
+
+        stuck_future: Future = Future()
+        req_id = 99998
+        connected_bridge._pending[req_id] = stuck_future
+        try:
+            with pytest.raises(BridgeTimeoutError):
+                try:
+                    stuck_future.result(timeout=0.05)
+                except FutureTimeoutError:
+                    connected_bridge._pending.pop(req_id, None)
+                    raise BridgeTimeoutError("Timed out: ps.testOp")
+        finally:
+            connected_bridge._pending.pop(req_id, None)
+
+    def test_timeout_cleans_up_pending(self, connected_bridge):
+        from concurrent.futures import Future
+        from concurrent.futures import TimeoutError as FutureTimeoutError
+
+        from dcc_mcp_photoshop.bridge import BridgeTimeoutError
+
+        stuck_future: Future = Future()
+        req_id = 99997
+        connected_bridge._pending[req_id] = stuck_future
+        try:
+            try:
+                stuck_future.result(timeout=0.05)
+            except FutureTimeoutError:
+                connected_bridge._pending.pop(req_id, None)
+                raise BridgeTimeoutError("Timed out")
+        except BridgeTimeoutError:
+            pass
+        assert req_id not in connected_bridge._pending
+
+
+# ---------------------------------------------------------------------------
+# Disconnect / reconnect behavior
+# ---------------------------------------------------------------------------
+
+
+class TestDisconnectBehavior:
+    def test_disconnect_clears_pending_calls(self, connected_bridge):
+        from concurrent.futures import Future
+
+        from dcc_mcp_photoshop.bridge import BridgeConnectionError
+
+        stuck_future: Future = Future()
+        req_id = 99996
+        connected_bridge._pending[req_id] = stuck_future
+        for f in connected_bridge._pending.values():
+            if not f.done():
+                f.set_exception(BridgeConnectionError("UXP plugin disconnected"))
+        connected_bridge._pending.clear()
+        assert req_id not in connected_bridge._pending
+        assert stuck_future.done()
+        with pytest.raises(BridgeConnectionError):
+            stuck_future.result(timeout=0)
+
+    def test_call_when_disconnected_raises(self):
+        from dcc_mcp_photoshop.bridge import BridgeConnectionError, PhotoshopBridge
+
+        bridge = PhotoshopBridge()
+        with pytest.raises(BridgeConnectionError):
+            bridge.call("ps.getDocumentInfo")
+
+
+# ---------------------------------------------------------------------------
+# Progress notification format
+# ---------------------------------------------------------------------------
+
+
+class TestProgressNotification:
+    def test_progress_message_format(self):
+        from dcc_mcp_photoshop.protocol import build_progress
+
+        msg = build_progress(42, 3, 5, "Rendering...", "render")
+        assert msg["jsonrpc"] == "2.0"
+        assert msg["id"] == 42
+        assert msg["type"] == "progress"
+        assert msg["progress"]["current"] == 3
+        assert msg["progress"]["total"] == 5
+        assert msg["progress"]["message"] == "Rendering..."
+        assert msg["progress"]["stage"] == "render"
+
+    def test_progress_does_not_resolve_pending(self, connected_bridge):
+        from dcc_mcp_photoshop.protocol import is_progress
+
+        progress_msg = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "type": "progress",
+            "progress": {"current": 50, "total": 100},
+        }
+        assert is_progress(progress_msg)
+        assert "result" not in progress_msg
+        assert "error" not in progress_msg
+
+
+# ---------------------------------------------------------------------------
+# Protocol version compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolVersion:
+    def test_protocol_version_is_semver(self):
+        from dcc_mcp_photoshop.protocol import PROTOCOL_VERSION
+
+        parts = PROTOCOL_VERSION.split(".")
+        assert len(parts) == 3
+        assert all(p.isdigit() for p in parts)
+
+    def test_protocol_name_constant(self):
+        from dcc_mcp_photoshop.protocol import PROTOCOL_NAME
+
+        assert PROTOCOL_NAME == "photoshop-bridge"
+        assert isinstance(PROTOCOL_NAME, str)
+        assert len(PROTOCOL_NAME) > 0
+
+
+# ---------------------------------------------------------------------------
+# Concurrent request routing
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentRouting:
+    def test_interleaved_requests_correct_ids(self, connected_bridge):
+        r1 = connected_bridge.call("ps.getDocumentInfo")
+        r2 = connected_bridge.call("ps.listLayers", include_hidden=True)
+        r3 = connected_bridge.call("ps.listLayers", include_hidden=False)
+        r4 = connected_bridge.call("ps.listDocuments")
+        assert r1["name"] == "Untitled-1.psd"
+        assert len(r2) == 3
+        assert len(r3) == 2
+        assert len(r4) == 1

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -219,10 +219,16 @@ class TestHelloHandshake:
 
         async def _raw_client():
             ws = await websockets.connect(f"ws://localhost:{port}")
-            await ws.send(json.dumps({
-                "type": "hello", "protocol": "photoshop-bridge",
-                "version": "0.1.0", "client": "test-harness",
-            }))
+            await ws.send(
+                json.dumps(
+                    {
+                        "type": "hello",
+                        "protocol": "photoshop-bridge",
+                        "version": "0.1.0",
+                        "client": "test-harness",
+                    }
+                )
+            )
             raw = await ws.recv()
             ack = json.loads(raw)
             await ws.close()

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -8,12 +8,10 @@ from __future__ import annotations
 
 import asyncio
 import json
-import threading
 import time
 
 import pytest
 import websockets
-
 
 # ---------------------------------------------------------------------------
 # Message builder unit tests (no server needed)
@@ -76,7 +74,7 @@ class TestMessageBuilders:
         assert msg["result"] == {"exported": True}
 
     def test_build_error_known_code_auto_hint(self):
-        from dcc_mcp_photoshop.protocol import build_error, RPC_METHOD_NOT_FOUND
+        from dcc_mcp_photoshop.protocol import RPC_METHOD_NOT_FOUND, build_error
 
         msg = build_error(1, RPC_METHOD_NOT_FOUND, "Method not found: ps.unknown")
         assert msg["error"]["code"] == RPC_METHOD_NOT_FOUND
@@ -96,7 +94,7 @@ class TestMessageBuilders:
         assert msg["error"]["data"] == {"missing": ["name"]}
 
     def test_build_error_null_id(self):
-        from dcc_mcp_photoshop.protocol import build_error, RPC_PARSE_ERROR
+        from dcc_mcp_photoshop.protocol import RPC_PARSE_ERROR, build_error
 
         msg = build_error(None, RPC_PARSE_ERROR, "Parse error")
         assert msg["id"] is None
@@ -339,9 +337,9 @@ class TestTimeoutBehavior:
             with pytest.raises(BridgeTimeoutError):
                 try:
                     stuck_future.result(timeout=0.05)
-                except FutureTimeoutError:
+                except FutureTimeoutError as err:
                     connected_bridge._pending.pop(req_id, None)
-                    raise BridgeTimeoutError("Timed out: ps.testOp")
+                    raise BridgeTimeoutError("Timed out: ps.testOp") from err
         finally:
             connected_bridge._pending.pop(req_id, None)
 
@@ -357,9 +355,9 @@ class TestTimeoutBehavior:
         try:
             try:
                 stuck_future.result(timeout=0.05)
-            except FutureTimeoutError:
+            except FutureTimeoutError as err:
                 connected_bridge._pending.pop(req_id, None)
-                raise BridgeTimeoutError("Timed out")
+                raise BridgeTimeoutError("Timed out") from err
         except BridgeTimeoutError:
             pass
         assert req_id not in connected_bridge._pending


### PR DESCRIPTION
## Summary
- Define formal WebSocket bridge protocol v0.1.0 (photoshop-bridge)
- Add Python `protocol.py` module with message builders, validators, and error codes
- Update UXP plugin (`jsonrpc.js`, `bridge-client.js`) for protocol v0 lifecycle
- Add hello handshake, extended error envelopes (hint field), progress notifications, disconnect lifecycle
- 34 contract tests in `test_protocol.py` using mock UXP WebSocket peer

## Test plan
- [x] All 144 tests pass locally (`uv run pytest tests/ --ignore=tests/test_plugin_sidecar_launcher.py`)
- [x] Protocol unit tests cover message builders, validators, error envelopes
- [x] Protocol integration tests cover hello handshake, request/response, errors, timeout, disconnect

Closes: https://github.com/dcc-mcp/dcc-mcp-photoshop/issues/5