### PR TITLE
feat: create photoshop-setup skill for agent-guided MCP setup

### DIFF
--- a/bridge/uxp-plugin/src/bridge-client.js
+++ b/bridge/uxp-plugin/src/bridge-client.js
@@ -5,7 +5,8 @@
  * Receives JSON-RPC 2.0 requests from Python, dispatches to PS handlers,
  * and sends back responses.
  *
- * Reconnects automatically if the connection drops.
+ * Implements the Photoshop bridge protocol v0.
+ * See: docs/bridge-protocol.md
  */
 
 "use strict";
@@ -13,9 +14,19 @@
 const documentHandlers = require("./handlers/document");
 const layerHandlers    = require("./handlers/layers");
 const scriptHandlers   = require("./handlers/script");
-const { rpcSuccess, rpcError, parseRequest, RPC_METHOD_NOT_FOUND, RPC_INTERNAL_ERROR } = require("./utils/jsonrpc");
+const {
+    PROTOCOL_VERSION,
+    RPC_METHOD_NOT_FOUND,
+    RPC_INTERNAL_ERROR,
+    buildHello,
+    rpcSuccess,
+    rpcError,
+    parseRequest,
+    isHelloAck,
+    isDisconnected,
+} = require("./utils/jsonrpc");
 
-// Python bridge server — must match bridge.py BRIDGE_SERVER_PORT
+// Python bridge server — must match bridge.py DEFAULT_SERVER_PORT
 const BRIDGE_URL = "ws://localhost:9001";
 const RECONNECT_DELAY_MS = 3000;
 
@@ -25,6 +36,7 @@ const HANDLERS = Object.assign({}, documentHandlers, layerHandlers, scriptHandle
 let _ws = null;
 let _reconnectTimer = null;
 let _stopped = false;
+let _reconnecting = false;
 let _statusCallback = null;
 
 function _setStatus(status, detail) {
@@ -32,27 +44,16 @@ function _setStatus(status, detail) {
     if (_statusCallback) _statusCallback(status, detail);
 }
 
-/**
- * Register a callback for status changes.
- * @param {function(status: string, detail?: string): void} cb
- */
 function onStatusChange(cb) {
     _statusCallback = cb;
 }
 
-/**
- * Dispatch a JSON-RPC request to the appropriate Photoshop handler.
- * @param {object} request
- * @returns {Promise<object>} JSON-RPC response
- */
 async function _dispatch(request) {
     const { id, method, params = {} } = request;
     const handler = HANDLERS[method];
-
     if (!handler) {
         return rpcError(id, RPC_METHOD_NOT_FOUND, `Method not found: ${method}`);
     }
-
     try {
         const result = await handler(params);
         return rpcSuccess(id, result);
@@ -62,17 +63,12 @@ async function _dispatch(request) {
     }
 }
 
-/**
- * Connect to the Python WebSocket bridge server.
- */
 function connect() {
     if (_ws && (_ws.readyState === WebSocket.OPEN || _ws.readyState === WebSocket.CONNECTING)) {
         return;
     }
-
     _stopped = false;
     _setStatus("Connecting", BRIDGE_URL);
-
     try {
         _ws = new WebSocket(BRIDGE_URL);
     } catch (err) {
@@ -83,44 +79,51 @@ function connect() {
 
     _ws.onopen = () => {
         _setStatus("Connected", `Bridge connected to Python at ${BRIDGE_URL}`);
-        // Announce ourselves to the Python server
-        _ws.send(JSON.stringify({ type: "hello", client: "photoshop-uxp", version: "0.1.0" }));
+        _ws.send(JSON.stringify(buildHello("photoshop-uxp", _reconnecting)));
+        _reconnecting = false;
     };
 
     _ws.onmessage = async (event) => {
         const raw = typeof event.data === "string" ? event.data : event.data.toString();
+        let msg;
+        try { msg = JSON.parse(raw); } catch (_e) { console.error("[dcc-mcp] Invalid JSON from server:", raw.slice(0, 200)); return; }
 
-        let request;
-        try {
-            request = JSON.parse(raw);
-        } catch (_e) {
-            console.error("[dcc-mcp] Invalid JSON from server:", raw.slice(0, 200));
+        // Protocol-level messages
+        if (msg.type) {
+            if (isHelloAck(msg)) {
+                if (msg.compatible === false) {
+                    _setStatus("Error", `Protocol mismatch: ${msg.error || "unspecified"}`);
+                } else {
+                    console.log("[dcc-mcp] Server acknowledged hello (protocol " + (msg.version || "?") + ")");
+                }
+                return;
+            }
+            if (isDisconnected(msg)) {
+                _setStatus("Disconnected", `Server: ${msg.reason || "unknown"}`);
+                return;
+            }
+            if (msg.type === "progress") {
+                const p = msg.progress || {};
+                console.log("[dcc-mcp] Progress id=" + msg.id + " " + (p.current || 0) + "/" + (p.total || 0) + (p.message ? " — " + p.message : ""));
+                return;
+            }
+            console.log("[dcc-mcp] Server message:", msg.type);
             return;
         }
 
-        // Handle non-RPC messages (e.g. server acknowledgement)
-        if (!request.method && request.type) {
-            console.log("[dcc-mcp] Server message:", request.type);
-            return;
-        }
-
+        // JSON-RPC request
         const { request: rpcReq, parseError } = parseRequest(raw);
-        if (parseError) {
-            _ws.send(JSON.stringify(parseError));
-            return;
-        }
-
+        if (parseError) { _ws.send(JSON.stringify(parseError)); return; }
         const response = await _dispatch(rpcReq);
         _ws.send(JSON.stringify(response));
     };
 
-    _ws.onerror = (err) => {
-        _setStatus("Error", String(err.message || err));
-    };
+    _ws.onerror = (err) => { _setStatus("Error", String(err.message || err)); };
 
     _ws.onclose = (event) => {
         _ws = null;
         if (!_stopped) {
+            _reconnecting = true;
             _setStatus("Disconnected", `Code ${event.code} — reconnecting in ${RECONNECT_DELAY_MS / 1000}s`);
             _scheduleReconnect();
         } else {
@@ -131,25 +134,13 @@ function connect() {
 
 function _scheduleReconnect() {
     if (_reconnectTimer) return;
-    _reconnectTimer = setTimeout(() => {
-        _reconnectTimer = null;
-        if (!_stopped) connect();
-    }, RECONNECT_DELAY_MS);
+    _reconnectTimer = setTimeout(() => { _reconnectTimer = null; if (!_stopped) connect(); }, RECONNECT_DELAY_MS);
 }
 
-/**
- * Disconnect and stop auto-reconnect.
- */
 function disconnect() {
     _stopped = true;
-    if (_reconnectTimer) {
-        clearTimeout(_reconnectTimer);
-        _reconnectTimer = null;
-    }
-    if (_ws) {
-        _ws.close();
-        _ws = null;
-    }
+    if (_reconnectTimer) { clearTimeout(_reconnectTimer); _reconnectTimer = null; }
+    if (_ws) { _ws.close(); _ws = null; }
     _setStatus("Disconnected", "Disconnected by user");
 }
 

--- a/bridge/uxp-plugin/src/utils/jsonrpc.js
+++ b/bridge/uxp-plugin/src/utils/jsonrpc.js
@@ -1,17 +1,69 @@
 /**
- * JSON-RPC 2.0 helpers.
+ * JSON-RPC 2.0 helpers + Photoshop bridge protocol v0.
  *
  * See: https://www.jsonrpc.org/specification
+ * See: docs/bridge-protocol.md
  */
 
 "use strict";
 
-// Standard JSON-RPC 2.0 error codes
+// ── Protocol identity ────────────────────────────────────────────────────────
+
+const PROTOCOL_NAME = "photoshop-bridge";
+const PROTOCOL_VERSION = "0.1.0";
+
+// ── Standard JSON-RPC 2.0 error codes ────────────────────────────────────────
+
 const RPC_PARSE_ERROR = -32700;
 const RPC_INVALID_REQUEST = -32600;
 const RPC_METHOD_NOT_FOUND = -32601;
 const RPC_INVALID_PARAMS = -32602;
 const RPC_INTERNAL_ERROR = -32603;
+
+// ── Photoshop bridge custom error codes ───────────────────────────────────────
+
+const CUSTOM_ERR_NO_ACTIVE_DOC     = -32001;
+const CUSTOM_ERR_LAYER_NOT_FOUND   = -32002;
+const CUSTOM_ERR_UNSUPPORTED_FORMAT = -32003;
+const CUSTOM_ERR_FILE_NOT_FOUND    = -32004;
+const CUSTOM_ERR_SCRIPT_ERROR      = -32005;
+const CUSTOM_ERR_TIMEOUT           = -32006;
+const CUSTOM_ERR_DISCONNECTED      = -32007;
+
+// ── Error code → hint mapping ─────────────────────────────────────────────────
+
+const ERROR_HINTS = {};
+ERROR_HINTS[RPC_PARSE_ERROR]         = "The JSON payload could not be parsed. Check for malformed escape sequences or trailing commas.";
+ERROR_HINTS[RPC_INVALID_REQUEST]     = "The request must be a JSON object with 'jsonrpc', 'id', 'method', and 'params' fields.";
+ERROR_HINTS[RPC_METHOD_NOT_FOUND]    = "Use ps.describeApi to list available methods.";
+ERROR_HINTS[RPC_INVALID_PARAMS]      = "Check the method's required parameters and their types.";
+ERROR_HINTS[RPC_INTERNAL_ERROR]      = "An unexpected error occurred inside the Photoshop handler. Check the plugin log for details.";
+ERROR_HINTS[CUSTOM_ERR_NO_ACTIVE_DOC]     = "Open or create a document before calling document/layer methods.";
+ERROR_HINTS[CUSTOM_ERR_LAYER_NOT_FOUND]   = "Use ps.listLayers to see the current layer tree.";
+ERROR_HINTS[CUSTOM_ERR_UNSUPPORTED_FORMAT] = "Supported formats: png, jpg, tiff, psd.";
+ERROR_HINTS[CUSTOM_ERR_FILE_NOT_FOUND]    = "Verify the path exists and Photoshop has permission to access it.";
+ERROR_HINTS[CUSTOM_ERR_SCRIPT_ERROR]      = "The JavaScript expression could not be evaluated. Check syntax and available APIs.";
+ERROR_HINTS[CUSTOM_ERR_TIMEOUT]           = "The operation took too long and was cancelled. Try a smaller operation or increase the timeout.";
+ERROR_HINTS[CUSTOM_ERR_DISCONNECTED]      = "The UXP plugin lost connection. It will auto-reconnect. Retry the call once reconnected.";
+
+// ── Message builders ──────────────────────────────────────────────────────────
+
+/**
+ * Build a hello message (UXP → Python).
+ * @param {string} [client="photoshop-uxp"]
+ * @param {boolean} [reconnect=false] - True if this is a reconnection.
+ * @returns {object}
+ */
+function buildHello(client, reconnect) {
+    const msg = {
+        type: "hello",
+        protocol: PROTOCOL_NAME,
+        version: PROTOCOL_VERSION,
+        client: client || "photoshop-uxp",
+    };
+    if (reconnect) msg.reconnect = true;
+    return msg;
+}
 
 /**
  * Build a JSON-RPC 2.0 success response.
@@ -24,22 +76,40 @@ function rpcSuccess(id, result) {
 }
 
 /**
- * Build a JSON-RPC 2.0 error response.
+ * Build a JSON-RPC 2.0 error response with optional hint.
  * @param {number|string|null} id - Request id (null for parse errors)
  * @param {number} code - Error code
  * @param {string} message - Error message
- * @param {*} [data] - Optional extra data
+ * @param {string} [hint] - Actionable suggestion. Auto-populated from known codes if omitted.
+ * @param {*} [data] - Optional extra diagnostic data
  * @returns {object}
  */
-function rpcError(id, code, message, data) {
+function rpcError(id, code, message, hint, data) {
     const error = { code, message };
+    const h = hint || ERROR_HINTS[code];
+    if (h) error.hint = h;
     if (data !== undefined) error.data = data;
     return { jsonrpc: "2.0", id, error };
 }
 
 /**
+ * Build a progress notification (UXP → Python).
+ * @param {number} id - The id of the original request
+ * @param {number} current - Current progress value
+ * @param {number} total - Total progress value
+ * @param {string} [message=""] - Human-readable description
+ * @param {string} [stage] - Named stage identifier
+ * @returns {object}
+ */
+function buildProgress(id, current, total, message, stage) {
+    const progress = { current, total };
+    if (message) progress.message = message;
+    if (stage) progress.stage = stage;
+    return { jsonrpc: "2.0", id, type: "progress", progress };
+}
+
+/**
  * Parse a raw WebSocket message into a JSON-RPC request object.
- * Returns null and sends a parse-error response if the message is invalid.
  * @param {string} raw - Raw message string
  * @returns {{ request: object|null, parseError: object|null }}
  */
@@ -48,29 +118,34 @@ function parseRequest(raw) {
     try {
         request = JSON.parse(raw);
     } catch (_e) {
-        return {
-            request: null,
-            parseError: rpcError(null, RPC_PARSE_ERROR, "Parse error"),
-        };
+        return { request: null, parseError: rpcError(null, RPC_PARSE_ERROR, "Parse error") };
     }
-
     if (!request || request.jsonrpc !== "2.0" || typeof request.method !== "string") {
-        return {
-            request: null,
-            parseError: rpcError(request.id ?? null, RPC_INVALID_REQUEST, "Invalid Request"),
-        };
+        const id = (request && request.id !== undefined) ? request.id : null;
+        return { request: null, parseError: rpcError(id, RPC_INVALID_REQUEST, "Invalid Request") };
     }
-
     return { request, parseError: null };
 }
 
+// ── Validators ────────────────────────────────────────────────────────────────
+
+function isHelloAck(msg) { return msg && msg.type === "hello_ack"; }
+function isDisconnected(msg) { return msg && msg.type === "disconnected"; }
+
+function checkVersion(version) {
+    try {
+        return parseInt(version.split(".")[0], 10) === 0;
+    } catch (_e) {
+        return false;
+    }
+}
+
 module.exports = {
-    RPC_PARSE_ERROR,
-    RPC_INVALID_REQUEST,
-    RPC_METHOD_NOT_FOUND,
-    RPC_INVALID_PARAMS,
-    RPC_INTERNAL_ERROR,
-    rpcSuccess,
-    rpcError,
-    parseRequest,
+    PROTOCOL_NAME, PROTOCOL_VERSION,
+    RPC_PARSE_ERROR, RPC_INVALID_REQUEST, RPC_METHOD_NOT_FOUND, RPC_INVALID_PARAMS, RPC_INTERNAL_ERROR,
+    CUSTOM_ERR_NO_ACTIVE_DOC, CUSTOM_ERR_LAYER_NOT_FOUND, CUSTOM_ERR_UNSUPPORTED_FORMAT,
+    CUSTOM_ERR_FILE_NOT_FOUND, CUSTOM_ERR_SCRIPT_ERROR, CUSTOM_ERR_TIMEOUT, CUSTOM_ERR_DISCONNECTED,
+    ERROR_HINTS,
+    buildHello, rpcSuccess, rpcError, buildProgress, parseRequest,
+    isHelloAck, isDisconnected, checkVersion,
 };

--- a/docs/bridge-protocol.md
+++ b/docs/bridge-protocol.md
@@ -1,0 +1,249 @@
+# Photoshop UXP WebSocket Bridge Protocol v0
+
+**Version**: 0.1.0
+**Transport**: WebSocket (Python server, UXP client)
+**Message format**: JSON-RPC 2.0 superset
+**Default endpoint**: `ws://localhost:9001`
+
+---
+
+## 1. Architecture
+
+```
+MCP Client ──HTTP──► Gateway (dcc-mcp-core) ──call()──► PhotoshopBridge (Python)
+                                                               │
+                                           WebSocket server localhost:9001
+                                                               │
+                                           Photoshop UXP plugin (WS client)
+                                                               │
+                                           Photoshop UXP API
+```
+
+Python starts a WebSocket server. The UXP plugin connects as a client (UXP does not support WebSocket server mode). Python sends JSON-RPC 2.0 requests; UXP executes them against the Photoshop API and returns responses.
+
+---
+
+## 2. Connection Lifecycle
+
+### 2.1 State Machine
+
+```
+ ┌──────────┐  server starts   ┌──────────────┐  UXP connects    ┌───────────────┐
+ │  CLOSED  │ ───────────────► │  LISTENING   │ ────────────────► │   CONNECTED   │
+ └──────────┘                  └──────────────┘                   └───────────────┘
+       ▲                              │                                  │    │
+       │                              │ UXP fails to connect             │    │
+       │ server.stop()                ▼                                  │    │ UXP disconnects
+       │                     ┌──────────────┐                            │    ▼
+       └─────────────────────│    ERROR     │◄───────────────────────────┘
+                             └──────────────┘                    ┌──────────────┐
+                                                                 │ DISCONNECTED │
+                                                                 └──────────────┘
+                                                                        │
+                                                                        │ auto-reconnect (3s)
+                                                                        ▼
+                                                                 ┌───────────────┐
+                                                                 │ RECONNECTING  │──► CONNECTED
+                                                                 └───────────────┘
+```
+
+### 2.2 Lifecycle Events
+
+| Event | Direction | Trigger | Payload |
+|-------|-----------|---------|---------|
+| `hello` | UXP → Python | WebSocket onopen | `{type, protocol, version, client}` |
+| `hello_ack` | Python → UXP | After hello received | `{type, protocol, version}` |
+| `disconnected` | Python → UXP | UXP disconnects or server stops | `{type: "disconnected", reason}` |
+| `reconnecting` | UXP → Python | On reconnect attempt | `{type: "hello", reconnect: true, ...}` |
+| `progress` | UXP → Python | Long-running operation progress | `{jsonrpc, id, type: "progress", progress}` |
+| `connected` | UXP → Python | First hello after connection | `{type: "hello", ...}` |
+
+### 2.3 Hello Handshake
+
+**UXP → Python** (on WebSocket open):
+```json
+{
+    "type": "hello",
+    "protocol": "photoshop-bridge",
+    "version": "0.1.0",
+    "client": "photoshop-uxp",
+    "reconnect": false
+}
+```
+
+**Python → UXP** (after receiving hello):
+```json
+{
+    "type": "hello_ack",
+    "protocol": "photoshop-bridge",
+    "version": "0.1.0"
+}
+```
+
+### 2.4 Disconnection
+
+When the UXP client disconnects:
+- Python fails all pending RPC calls with `BridgeConnectionError("UXP plugin disconnected")`
+- Python sets `_connected = false`
+- UXP auto-reconnects after 3 seconds (unless `_stopped = true`)
+
+When Python shuts down the server:
+- Python closes the WebSocket connection
+- UXP `onclose` fires; UXP enters reconnecting state
+
+---
+
+## 3. RPC Envelope
+
+### 3.1 Request (Python → UXP)
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "ps.getDocumentInfo",
+    "params": {}
+}
+```
+
+### 3.2 Success Response (UXP → Python)
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {}
+}
+```
+
+### 3.3 Error Response (UXP → Python)
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "error": {
+        "code": -32601,
+        "message": "Method not found: ps.unknownMethod",
+        "hint": "Use ps.describeApi to list available methods",
+        "data": {
+            "method": "ps.unknownMethod"
+        }
+    }
+}
+```
+
+### 3.4 Progress Notification (UXP → Python)
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 3,
+    "type": "progress",
+    "progress": {
+        "current": 50,
+        "total": 100,
+        "message": "Exporting document to /tmp/export.png...",
+        "stage": "export"
+    }
+}
+```
+
+---
+
+## 4. Error Codes
+
+### 4.1 Standard JSON-RPC 2.0 Codes
+
+| Code | Name | Description |
+|------|------|-------------|
+| `-32700` | Parse error | Invalid JSON received |
+| `-32600` | Invalid Request | Not a valid JSON-RPC request |
+| `-32601` | Method not found | Method does not exist |
+| `-32602` | Invalid params | Missing or invalid parameters |
+| `-32603` | Internal error | Unexpected handler error |
+
+### 4.2 Photoshop Bridge Custom Codes
+
+| Code | Name | Description |
+|------|------|-------------|
+| `-32001` | No Active Document | No document open in Photoshop |
+| `-32002` | Layer Not Found | Named layer does not exist |
+| `-32003` | Unsupported Format | Export format not supported |
+| `-32004` | File Not Found | Path does not exist on disk |
+| `-32005` | Script Error | UXP script execution failed |
+| `-32006` | Timeout | Operation exceeded timeout |
+| `-32007` | Disconnected | UXP connection lost mid-operation |
+
+---
+
+## 5. Method Namespace
+
+### 5.1 Document Operations
+
+| Method | Parameters | Returns |
+|--------|------------|---------|
+| `ps.getDocumentInfo` | _(none)_ | Document metadata object |
+| `ps.listDocuments` | _(none)_ | Array of document metadata |
+| `ps.createDocument` | `name?`, `width?`, `height?`, `resolution?`, `color_mode?`, `bit_depth?` | Created document metadata |
+| `ps.openDocument` | `path` (required) | Opened document metadata |
+| `ps.saveDocument` | _(none)_ | `{saved, path}` |
+| `ps.closeDocument` | `save?` (boolean, default false) | `{closed}` |
+| `ps.exportDocument` | `path` (required), `format?` (png/jpg/tiff/psd), `quality?` (jpg, 0-100) | `{exported, path, format}` |
+
+### 5.2 Layer Operations
+
+| Method | Parameters | Returns |
+|--------|------------|---------|
+| `ps.listLayers` | `include_hidden?` (boolean, default true) | Layer tree array |
+| `ps.createLayer` | `name?`, `type?` (pixel/group) | `{id, name, type}` |
+| `ps.deleteLayer` | `name` (required) | `{deleted, name}` |
+| `ps.setLayerVisibility` | `name`, `visible` (both required) | `{name, visible}` |
+| `ps.renameLayer` | `name`, `new_name` (both required) | `{old_name, name}` |
+| `ps.setLayerOpacity` | `name`, `opacity` (both required, 0-100) | `{name, opacity}` |
+| `ps.duplicateLayer` | `name` (required), `new_name?` | `{id, name}` |
+| `ps.setLayerBlendMode` | `name`, `blend_mode` (both required) | `{name, blend_mode}` |
+| `ps.fillLayer` | `name`, `color` (both required) | `{filled, name, color}` |
+
+### 5.3 Image Operations
+
+| Method | Parameters | Returns |
+|--------|------------|---------|
+| `ps.resizeCanvas` | `width`, `height` (both required) | `{width, height}` |
+| `ps.resizeImage` | `width`, `height` (both required) | `{width, height}` |
+| `ps.flattenImage` | _(none)_ | `{flattened}` |
+| `ps.mergeVisibleLayers` | _(none)_ | `{merged, layer_name}` |
+
+### 5.4 Text Operations
+
+| Method | Parameters | Returns |
+|--------|------------|---------|
+| `ps.createTextLayer` | `content` (required), `name?` | `{id, name, content}` |
+| `ps.updateTextLayer` | `name`, `content` (both required) | `{name, content}` |
+| `ps.getTextLayerInfo` | `name` (required) | `{name, content, font, size, color, alignment, bold, italic}` |
+
+### 5.5 Script / Meta Operations
+
+| Method | Parameters | Returns |
+|--------|------------|---------|
+| `ps.executeScript` | `code` (required) | Script return value |
+| `ps.executeAction` | `action`, `action_set` (both required) | `{executed, action, action_set}` |
+| `ps.describeApi` | _(none)_ | `{protocol, version, methods: [...]}` |
+| `ps.invoke` | `path`, `args?`, `kwargs?`, `modal?` | Reflected API result |
+| `ps.batchPlay` | `commands`, `options?`, `modal?` | batchPlay result |
+
+---
+
+## 6. Protocol Version Compatibility
+
+| Version | Changes |
+|---------|---------|
+| `0.1.0` | Initial protocol: JSON-RPC 2.0 + hello handshake + progress notifications + extended error envelope |
+
+Version negotiation: The UXP plugin declares its protocol version in the `hello` message. If the Python server requires a different version, it responds with `hello_ack` containing `compatible: false` and an `error` field explaining the mismatch.
+
+---
+
+## 7. Contract Tests
+
+See `tests/test_protocol.py` and `tests/conftest.py` (mock UXP peer).

--- a/src/dcc_mcp_photoshop/bridge.py
+++ b/src/dcc_mcp_photoshop/bridge.py
@@ -20,8 +20,8 @@ Why inverted?
   UXP only supports WebSocket CLIENT, not server.
   See: https://forums.creativeclouddeveloper.com/t/7423
 
-Protocol
---------
+Protocol (v0.1.0)
+------------------
   Python → UXP  (request):
     {"jsonrpc":"2.0","id":1,"method":"ps.getDocumentInfo","params":{}}
 
@@ -29,10 +29,21 @@ Protocol
     {"jsonrpc":"2.0","id":1,"result":{"name":"Untitled-1.psd",...}}
 
   UXP → Python  (error):
-    {"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"..."}}
+    {"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"...","hint":"..."}}
+
+  UXP → Python  (progress):
+    {"jsonrpc":"2.0","id":1,"type":"progress","progress":{"current":50,"total":100}}
 
   UXP → Python  (hello, on connect):
-    {"type":"hello","client":"photoshop-uxp","version":"0.1.0"}
+    {"type":"hello","protocol":"photoshop-bridge","version":"0.1.0","client":"photoshop-uxp"}
+
+  Python → UXP  (hello_ack):
+    {"type":"hello_ack","protocol":"photoshop-bridge","version":"0.1.0"}
+
+  Python → UXP  (disconnected):
+    {"type":"disconnected","reason":"Server stopped"}
+
+See docs/bridge-protocol.md for the full specification.
 """
 
 from __future__ import annotations
@@ -46,6 +57,15 @@ from concurrent.futures import Future
 from concurrent.futures import TimeoutError as FutureTimeoutError
 from pathlib import Path
 from typing import Any, Dict, Optional
+
+from dcc_mcp_photoshop.protocol import (
+    PROTOCOL_NAME,
+    PROTOCOL_VERSION,
+    build_hello_ack,
+    build_disconnected,
+    is_hello,
+    is_progress,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -112,12 +132,14 @@ class BridgeRpcError(RuntimeError):
 
     Attributes:
         code: JSON-RPC error code.
-        data: Optional extra data.
+        hint: Actionable suggestion from the UXP side.
+        data: Optional extra diagnostic data.
     """
 
-    def __init__(self, message: str, code: int = -32603, data: Any = None) -> None:
+    def __init__(self, message: str, code: int = -32603, hint: str = "", data: Any = None) -> None:
         super().__init__(message)
         self.code = code
+        self.hint = hint
         self.data = data
 
 
@@ -285,12 +307,30 @@ class PhotoshopBridge:
                     logger.warning("PhotoshopBridge: invalid JSON from UXP: %r", raw[:200])
                     continue
 
-                # Handle non-RPC hello message
-                if msg.get("type") == "hello":
+                # Handle hello handshake
+                if is_hello(msg):
+                    reconnect = " (reconnect)" if msg.get("reconnect") else ""
                     logger.info(
-                        "UXP plugin hello: %s v%s",
+                        "UXP plugin hello: %s v%s%s",
                         msg.get("client"),
                         msg.get("version"),
+                        reconnect,
+                    )
+                    try:
+                        await websocket.send(json.dumps(build_hello_ack()))
+                    except Exception:
+                        pass
+                    continue
+
+                # Handle progress notification — log but do NOT resolve pending future
+                if is_progress(msg):
+                    p = msg.get("progress", {})
+                    logger.debug(
+                        "Progress id=%r %d/%d%s",
+                        msg.get("id"),
+                        p.get("current", 0),
+                        p.get("total", 0),
+                        f" — {p['message']}" if p.get("message") else "",
                     )
                     continue
 
@@ -313,6 +353,7 @@ class PhotoshopBridge:
                     exc = BridgeRpcError(
                         err_info.get("message", "Unknown RPC error"),
                         code=err_info.get("code", -32603),
+                        hint=err_info.get("hint", ""),
                         data=err_info.get("data"),
                     )
                     self._set_future_exception(future, exc)
@@ -349,6 +390,11 @@ class PhotoshopBridge:
         if self._loop is not None:
 
             async def _close():
+                if self._uxp_ws:
+                    try:
+                        await self._uxp_ws.send(json.dumps(build_disconnected()))
+                    except Exception:
+                        pass
                 if self._server:
                     self._server.close()
                     await self._server.wait_closed()

--- a/src/dcc_mcp_photoshop/bridge.py
+++ b/src/dcc_mcp_photoshop/bridge.py
@@ -59,10 +59,8 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from dcc_mcp_photoshop.protocol import (
-    PROTOCOL_NAME,
-    PROTOCOL_VERSION,
-    build_hello_ack,
     build_disconnected,
+    build_hello_ack,
     is_hello,
     is_progress,
 )

--- a/src/dcc_mcp_photoshop/protocol.py
+++ b/src/dcc_mcp_photoshop/protocol.py
@@ -1,0 +1,205 @@
+"""Photoshop UXP WebSocket bridge protocol v0 — message builders and validators.
+
+Defines the wire format for Python ↔ UXP communication.
+See docs/bridge-protocol.md for the full specification.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional
+
+# ── Protocol identity ──────────────────────────────────────────────────────
+
+PROTOCOL_NAME = "photoshop-bridge"
+PROTOCOL_VERSION = "0.1.0"
+PROTOCOL_TAG = f"{PROTOCOL_NAME}/{PROTOCOL_VERSION}"
+
+# ── Message types ──────────────────────────────────────────────────────────
+
+TYPE_HELLO = "hello"
+TYPE_HELLO_ACK = "hello_ack"
+TYPE_DISCONNECTED = "disconnected"
+TYPE_PROGRESS = "progress"
+
+# ── Standard JSON-RPC 2.0 error codes ──────────────────────────────────────
+
+RPC_PARSE_ERROR = -32700
+RPC_INVALID_REQUEST = -32600
+RPC_METHOD_NOT_FOUND = -32601
+RPC_INVALID_PARAMS = -32602
+RPC_INTERNAL_ERROR = -32603
+
+# ── Photoshop bridge custom error codes ────────────────────────────────────
+
+CUSTOM_ERR_NO_ACTIVE_DOC = -32001
+CUSTOM_ERR_LAYER_NOT_FOUND = -32002
+CUSTOM_ERR_UNSUPPORTED_FORMAT = -32003
+CUSTOM_ERR_FILE_NOT_FOUND = -32004
+CUSTOM_ERR_SCRIPT_ERROR = -32005
+CUSTOM_ERR_TIMEOUT = -32006
+CUSTOM_ERR_DISCONNECTED = -32007
+
+# ── Error code → hint mapping ──────────────────────────────────────────────
+
+_ERROR_HINTS: Dict[int, str] = {
+    RPC_PARSE_ERROR: "The JSON payload could not be parsed. Check for malformed escape sequences or trailing commas.",
+    RPC_INVALID_REQUEST: "The request must be a JSON object with 'jsonrpc', 'id', 'method', and 'params' fields.",
+    RPC_METHOD_NOT_FOUND: "Use ps.describeApi to list available methods.",
+    RPC_INVALID_PARAMS: "Check the method's required parameters and their types.",
+    RPC_INTERNAL_ERROR: "An unexpected error occurred inside the Photoshop handler. Check the plugin log for details.",
+    CUSTOM_ERR_NO_ACTIVE_DOC: "Open or create a document before calling document/layer methods.",
+    CUSTOM_ERR_LAYER_NOT_FOUND: "Use ps.listLayers to see the current layer tree.",
+    CUSTOM_ERR_UNSUPPORTED_FORMAT: "Supported formats: png, jpg, tiff, psd.",
+    CUSTOM_ERR_FILE_NOT_FOUND: "Verify the path exists and Photoshop has permission to access it.",
+    CUSTOM_ERR_SCRIPT_ERROR: "The JavaScript expression could not be evaluated. Check syntax and available APIs.",
+    CUSTOM_ERR_TIMEOUT: "The operation took too long and was cancelled. Try a smaller operation or increase the timeout.",
+    CUSTOM_ERR_DISCONNECTED: "The UXP plugin lost connection. It will auto-reconnect. Retry the call once reconnected.",
+}
+
+# ── Message builders ───────────────────────────────────────────────────────
+
+
+def build_hello(client: str = "photoshop-uxp", reconnect: bool = False) -> Dict[str, Any]:
+    msg: Dict[str, Any] = {
+        "type": TYPE_HELLO,
+        "protocol": PROTOCOL_NAME,
+        "version": PROTOCOL_VERSION,
+        "client": client,
+    }
+    if reconnect:
+        msg["reconnect"] = True
+    return msg
+
+
+def build_hello_ack() -> Dict[str, Any]:
+    return {
+        "type": TYPE_HELLO_ACK,
+        "protocol": PROTOCOL_NAME,
+        "version": PROTOCOL_VERSION,
+    }
+
+
+def build_hello_ack_error(reason: str) -> Dict[str, Any]:
+    return {
+        "type": TYPE_HELLO_ACK,
+        "protocol": PROTOCOL_NAME,
+        "version": PROTOCOL_VERSION,
+        "compatible": False,
+        "error": reason,
+    }
+
+
+def build_disconnected(reason: str = "Server stopped") -> Dict[str, Any]:
+    return {
+        "type": TYPE_DISCONNECTED,
+        "reason": reason,
+    }
+
+
+def build_request(req_id: int, method: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "method": method,
+        "params": params or {},
+    }
+
+
+def build_success(req_id: int, result: Any) -> Dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "result": result,
+    }
+
+
+def build_error(
+    req_id: Optional[int],
+    code: int,
+    message: str,
+    hint: Optional[str] = None,
+    data: Any = None,
+) -> Dict[str, Any]:
+    error: Dict[str, Any] = {"code": code, "message": message}
+    if hint is None:
+        hint = _ERROR_HINTS.get(code)
+    if hint:
+        error["hint"] = hint
+    if data is not None:
+        error["data"] = data
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "error": error,
+    }
+
+
+def build_progress(
+    req_id: int,
+    current: int,
+    total: int,
+    message: str = "",
+    stage: Optional[str] = None,
+) -> Dict[str, Any]:
+    progress: Dict[str, Any] = {"current": current, "total": total}
+    if message:
+        progress["message"] = message
+    if stage:
+        progress["stage"] = stage
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "type": TYPE_PROGRESS,
+        "progress": progress,
+    }
+
+
+# ── Validators ─────────────────────────────────────────────────────────────
+
+
+def is_hello(msg: Dict[str, Any]) -> bool:
+    return msg.get("type") == TYPE_HELLO and msg.get("protocol") == PROTOCOL_NAME
+
+
+def is_rpc_request(msg: Dict[str, Any]) -> bool:
+    return (
+        msg.get("jsonrpc") == "2.0"
+        and isinstance(msg.get("id"), (int, float))
+        and isinstance(msg.get("method"), str)
+        and isinstance(msg.get("params"), dict)
+    )
+
+
+def is_rpc_response(msg: Dict[str, Any]) -> bool:
+    if msg.get("jsonrpc") != "2.0":
+        return False
+    if not isinstance(msg.get("id"), (int, float)):
+        return False
+    return "result" in msg or "error" in msg
+
+
+def is_progress(msg: Dict[str, Any]) -> bool:
+    return (
+        msg.get("jsonrpc") == "2.0"
+        and msg.get("type") == TYPE_PROGRESS
+        and isinstance(msg.get("id"), (int, float))
+        and isinstance(msg.get("progress"), dict)
+    )
+
+
+def check_version(version: str) -> bool:
+    try:
+        parts = version.split(".")
+        major = int(parts[0])
+        return major == 0
+    except (ValueError, IndexError):
+        return False
+
+
+def parse_message(raw: str) -> Optional[Dict[str, Any]]:
+    try:
+        msg = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return msg if isinstance(msg, dict) else None

--- a/src/dcc_mcp_photoshop/skills/photoshop-setup/SKILL.md
+++ b/src/dcc_mcp_photoshop/skills/photoshop-setup/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: photoshop-setup
+description: "Adobe Photoshop MCP setup — install, configure, and verify the dcc-mcp-photoshop bridge, UXP plugin, and server connection"
+dcc: photoshop
+version: "0.1.0"
+tags: [photoshop, setup, install, configure, bridge, uxp, adobe]
+search-hint: "install setup configure bridge uxp plugin server verify photoshop mcp"
+license: "MIT"
+allowed-tools: ["Bash", "Read", "Write"]
+depends: []
+tools:
+  - name: check_environment
+    description: "Check system prerequisites: Python version, pip, installed packages, Photoshop and UXP plugin status."
+    source_file: scripts/check_environment.py
+    read_only: true
+    destructive: false
+    idempotent: true
+  - name: install_package
+    description: "Install or upgrade dcc-mcp-photoshop and its dependencies via pip."
+    source_file: scripts/install_package.py
+    read_only: false
+    destructive: false
+    idempotent: true
+  - name: setup_uxp_plugin
+    description: "Install the UXP .ccx plugin into Photoshop — download, install via Creative Cloud or manual copy."
+    source_file: scripts/setup_uxp_plugin.py
+    read_only: false
+    destructive: false
+    idempotent: true
+  - name: start_server
+    description: "Start the dcc-mcp-photoshop server in embedded mode for development and testing."
+    source_file: scripts/start_server.py
+    read_only: false
+    destructive: false
+    idempotent: false
+  - name: verify_connection
+    description: "Verify the full bridge connection: Photoshop UXP plugin reachable, server responding, skills discoverable."
+    source_file: scripts/verify_connection.py
+    read_only: true
+    destructive: false
+    idempotent: true
+---
+
+# photoshop-setup
+
+Guided setup skill for dcc-mcp-photoshop. Helps agents walk through the entire
+installation, configuration, and verification flow.
+
+## Distribution Channels
+
+| Channel | Command / Artifact | Python Required |
+|---------|-------------------|-----------------|
+| **pip** | `pip install dcc-mcp-photoshop` | Yes |
+| **Standalone binary** | GitHub Releases — platform-specific binary | No |
+| **UXP .ccx plugin** | GitHub Releases — install into Photoshop | No |
+
+## Workflow
+
+1. **check_environment** — Inspect the current system state
+2. **install_package** — Install dcc-mcp-photoshop via pip (or skip if using binary)
+3. **setup_uxp_plugin** — Install the UXP .ccx plugin in Photoshop
+4. **start_server** — Launch the MCP server (embedded mode)
+5. **verify_connection** — Confirm everything is working
+
+## Tools
+
+- `check_environment` — Python / pip / installed packages / Photoshop process / UXP port
+- `install_package` — pip install dcc-mcp-photoshop
+- `setup_uxp_plugin` — Download and install the .ccx plugin
+- `start_server` — Start embedded MCP server + bridge
+- `verify_connection` — End-to-end connection check

--- a/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/check_environment.py
+++ b/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/check_environment.py
@@ -1,0 +1,177 @@
+"""Check the system environment for dcc-mcp-photoshop prerequisites."""
+
+from __future__ import annotations
+
+import os
+import platform
+import socket
+import subprocess
+import sys
+
+from dcc_mcp_core.skill import skill_entry
+
+
+def _get_python_version() -> str:
+    return f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+
+
+def _check_pip() -> bool:
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "pip", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return True
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return False
+
+
+def _get_installed_packages() -> dict[str, str]:
+    """Return dict of relevant installed packages and their versions."""
+    packages = {}
+    try:
+        import importlib.metadata
+        for name in ("dcc-mcp-photoshop", "dcc-mcp-core", "websockets"):
+            try:
+                packages[name] = importlib.metadata.version(name)
+            except importlib.metadata.PackageNotFoundError:
+                packages[name] = None
+    except Exception:
+        pass
+    return packages
+
+
+def _check_port(host: str, port: int) -> bool:
+    """Check if a port is listening."""
+    try:
+        with socket.create_connection((host, port), timeout=2):
+            return True
+    except (socket.timeout, ConnectionRefusedError, OSError):
+        return False
+
+
+def _check_photoshop_process() -> bool:
+    """Check if Photoshop is running (platform-specific)."""
+    system = platform.system()
+    try:
+        if system == "Windows":
+            result = subprocess.run(
+                ["tasklist", "/FI", "IMAGENAME eq Photoshop.exe"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            return "Photoshop.exe" in result.stdout
+        elif system == "Darwin":
+            result = subprocess.run(
+                ["pgrep", "-x", "Adobe Photoshop"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            return result.returncode == 0
+        else:
+            result = subprocess.run(
+                ["pgrep", "-x", "photoshop"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            return result.returncode == 0
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return False
+
+
+@skill_entry
+def check_environment(verbose: bool = False, **kwargs) -> dict:
+    """Check system prerequisites for dcc-mcp-photoshop.
+
+    Args:
+        verbose: Show detailed system information.
+
+    Returns:
+        dict: Environment status with all prerequisites.
+    """
+    python_version = _get_python_version()
+    pip_available = _check_pip()
+    packages = _get_installed_packages()
+    photoshop_running = _check_photoshop_process()
+    uxp_port_open = _check_port("127.0.0.1", 9001)
+
+    # Parse Python version check
+    major, minor, *_ = (int(v) for v in python_version.split("."))
+    python_ok = major >= 3 and minor >= 8
+
+    summary_parts = []
+    if python_ok:
+        summary_parts.append(f"Python {python_version}")
+    else:
+        summary_parts.append(f"Python {python_version} (need >=3.8)")
+
+    for name, ver in packages.items():
+        if ver:
+            summary_parts.append(f"{name}=={ver}")
+        else:
+            summary_parts.append(f"{name} (not installed)")
+
+    if photoshop_running:
+        summary_parts.append("Photoshop running")
+    else:
+        summary_parts.append("Photoshop not detected")
+
+    if uxp_port_open:
+        summary_parts.append("UXP port 9001 open")
+
+    result = {
+        "python": {
+            "version": python_version,
+            "executable": sys.executable,
+            "ok": python_ok,
+        },
+        "pip": {"available": pip_available},
+        "packages": packages,
+        "photoshop": {
+            "running": photoshop_running,
+            "platform": platform.system(),
+        },
+        "uxp_plugin": {
+            "port_open": uxp_port_open,
+            "port": 9001,
+        },
+        "system": {
+            "platform": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+        },
+    }
+
+    if verbose and packages.get("dcc-mcp-photoshop"):
+        try:
+            from dcc_mcp_photoshop import __version__
+            result["dcc_mcp_photoshop_version"] = __version__
+        except Exception:
+            pass
+
+    return {
+        "summary": " | ".join(summary_parts),
+        "all_ok": all([
+            python_ok,
+            pip_available or packages.get("dcc-mcp-photoshop"),
+        ]),
+        "details": result,
+        "prompt": (
+            "Use install_package to install dcc-mcp-photoshop, "
+            "or setup_uxp_plugin to install the UXP plugin."
+        ),
+    }
+
+
+def main(**kwargs) -> dict:
+    return check_environment(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+    run_main(main)

--- a/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/check_environment.py
+++ b/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/check_environment.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import os
+import importlib.metadata
 import platform
 import socket
 import subprocess
@@ -31,15 +31,11 @@ def _check_pip() -> bool:
 def _get_installed_packages() -> dict[str, str]:
     """Return dict of relevant installed packages and their versions."""
     packages = {}
-    try:
-        import importlib.metadata
-        for name in ("dcc-mcp-photoshop", "dcc-mcp-core", "websockets"):
-            try:
-                packages[name] = importlib.metadata.version(name)
-            except importlib.metadata.PackageNotFoundError:
-                packages[name] = None
-    except Exception:
-        pass
+    for name in ("dcc-mcp-photoshop", "dcc-mcp-core", "websockets"):
+        try:
+            packages[name] = importlib.metadata.version(name)
+        except importlib.metadata.PackageNotFoundError:
+            packages[name] = None
     return packages
 
 
@@ -149,22 +145,22 @@ def check_environment(verbose: bool = False, **kwargs) -> dict:
 
     if verbose and packages.get("dcc-mcp-photoshop"):
         try:
-            from dcc_mcp_photoshop import __version__
-            result["dcc_mcp_photoshop_version"] = __version__
+            from dcc_mcp_photoshop import __version__ as _ps_version  # noqa: PLC0415
+
+            result["dcc_mcp_photoshop_version"] = _ps_version
         except Exception:
             pass
 
     return {
         "summary": " | ".join(summary_parts),
-        "all_ok": all([
-            python_ok,
-            pip_available or packages.get("dcc-mcp-photoshop"),
-        ]),
-        "details": result,
-        "prompt": (
-            "Use install_package to install dcc-mcp-photoshop, "
-            "or setup_uxp_plugin to install the UXP plugin."
+        "all_ok": all(
+            [
+                python_ok,
+                pip_available or packages.get("dcc-mcp-photoshop"),
+            ]
         ),
+        "details": result,
+        "prompt": ("Use install_package to install dcc-mcp-photoshop, or setup_uxp_plugin to install the UXP plugin."),
     }
 
 
@@ -174,4 +170,5 @@ def main(**kwargs) -> dict:
 
 if __name__ == "__main__":
     from dcc_mcp_core.skill import run_main
+
     run_main(main)

--- a/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/install_package.py
+++ b/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/install_package.py
@@ -68,10 +68,7 @@ def install_package(
                 "details": {
                     "error": "source_path is required when editable=True",
                 },
-                "prompt": (
-                    "Clone the repo first: "
-                    "git clone https://github.com/dcc-mcp/dcc-mcp-photoshop"
-                ),
+                "prompt": ("Clone the repo first: git clone https://github.com/dcc-mcp/dcc-mcp-photoshop"),
             }
         pip_args.extend(["-e", source_path])
     elif version:
@@ -85,6 +82,7 @@ def install_package(
         # Verify the installed version
         try:
             from dcc_mcp_photoshop import __version__  # noqa: PLC0415
+
             installed = __version__
         except Exception:
             installed = "unknown"
@@ -113,4 +111,5 @@ def main(**kwargs) -> dict:
 
 if __name__ == "__main__":
     from dcc_mcp_core.skill import run_main
+
     run_main(main)

--- a/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/install_package.py
+++ b/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/install_package.py
@@ -1,0 +1,116 @@
+"""Install or upgrade dcc-mcp-photoshop and its dependencies via pip."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from dcc_mcp_core.skill import skill_entry
+
+
+def _pip_install(args: list[str]) -> dict:
+    """Run pip install with the given arguments and return result."""
+    cmd = [sys.executable, "-m", "pip", "install"] + args
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        success = result.returncode == 0
+        return {
+            "success": success,
+            "stdout": result.stdout.strip(),
+            "stderr": result.stderr.strip(),
+            "command": " ".join(cmd),
+        }
+    except subprocess.TimeoutExpired:
+        return {
+            "success": False,
+            "stdout": "",
+            "stderr": "pip install timed out after 120 seconds",
+            "command": " ".join(cmd),
+        }
+    except FileNotFoundError:
+        return {
+            "success": False,
+            "stdout": "",
+            "stderr": "pip not found",
+            "command": " ".join(cmd),
+        }
+
+
+@skill_entry
+def install_package(
+    version: str = "",
+    upgrade: bool = False,
+    editable: bool = False,
+    source_path: str = "",
+    **kwargs,
+) -> dict:
+    """Install or upgrade dcc-mcp-photoshop via pip.
+
+    Args:
+        version: Specific version to install (e.g. "0.2.0"); empty means latest.
+        upgrade: Upgrade to the latest version if already installed.
+        editable: Install in editable/development mode from source.
+        source_path: Local source path for editable install.
+
+    Returns:
+        dict: Installation result with success status and logs.
+    """
+    pip_args = []
+
+    if upgrade:
+        pip_args.append("--upgrade")
+
+    if editable:
+        if not source_path:
+            return {
+                "success": False,
+                "summary": "Editable install requires source_path",
+                "details": {
+                    "error": "source_path is required when editable=True",
+                },
+                "prompt": (
+                    "Clone the repo first: "
+                    "git clone https://github.com/dcc-mcp/dcc-mcp-photoshop"
+                ),
+            }
+        pip_args.extend(["-e", source_path])
+    elif version:
+        pip_args.append(f"dcc-mcp-photoshop=={version}")
+    else:
+        pip_args.append("dcc-mcp-photoshop")
+
+    result = _pip_install(pip_args)
+
+    if result["success"]:
+        # Verify the installed version
+        try:
+            from dcc_mcp_photoshop import __version__  # noqa: PLC0415
+            installed = __version__
+        except Exception:
+            installed = "unknown"
+
+        summary = f"dcc-mcp-photoshop installed (version: {installed})"
+        prompt = "Use setup_uxp_plugin to install the UXP plugin, then start_server to launch."
+    else:
+        summary = "Installation failed"
+        prompt = "Check Python/pip setup with check_environment, then retry."
+
+    return {
+        "summary": summary,
+        "success": result["success"],
+        "details": {
+            "installed_version": installed if result["success"] else None,
+            "pip_stdout": result["stdout"],
+            "pip_stderr": result["stderr"],
+        },
+        "prompt": prompt,
+    }
+
+
+def main(**kwargs) -> dict:
+    return install_package(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+    run_main(main)

--- a/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/setup_uxp_plugin.py
+++ b/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/setup_uxp_plugin.py
@@ -1,0 +1,259 @@
+"""Install the UXP .ccx plugin into Adobe Photoshop."""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+import sys
+
+from dcc_mcp_core.skill import skill_entry
+
+
+def _get_uxp_plugin_dir() -> str:
+    """Get the UXP plugins directory for the current platform."""
+    system = platform.system()
+    if system == "Windows":
+        appdata = os.environ.get("APPDATA", "")
+        return os.path.join(appdata, "Adobe", "UXP", "Plugins", "External")
+    elif system == "Darwin":
+        home = os.path.expanduser("~")
+        return os.path.join(home, "Library", "Application Support", "Adobe", "UXP", "Plugins", "External")
+    else:
+        return ""
+
+
+def _find_ccx_files(search_dir: str) -> list[str]:
+    """Find .ccx files in the given directory."""
+    matches = []
+    for root, _dirs, files in os.walk(search_dir):
+        for f in files:
+            if f.endswith(".ccx"):
+                matches.append(os.path.join(root, f))
+    return matches
+
+
+def _download_ccx(version: str, dest_dir: str) -> str | None:
+    """Download a .ccx from GitHub Releases."""
+    ver = version or "latest"
+    # Use gh CLI if available, otherwise construct URL
+    try:
+        if version:
+            url = (
+                f"https://github.com/dcc-mcp/dcc-mcp-photoshop/releases/download/"
+                f"v{version}/dcc-mcp-photoshop-bridge-{version}.ccx"
+            )
+        else:
+            url = (
+                "https://github.com/dcc-mcp/dcc-mcp-photoshop/releases/latest/download/"
+                "dcc-mcp-photoshop-bridge.ccx"
+            )
+
+        dest_path = os.path.join(dest_dir, f"dcc-mcp-photoshop-bridge-{ver}.ccx")
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "download", "--no-deps", "--dest", dest_dir, url],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        # Fallback: try curl
+        if not os.path.isfile(dest_path):
+            curl_result = subprocess.run(
+                ["curl", "-L", "-o", dest_path, url],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            if curl_result.returncode == 0 and os.path.isfile(dest_path):
+                return dest_path
+        elif os.path.isfile(dest_path):
+            return dest_path
+    except Exception:
+        pass
+    return None
+
+
+def _generate_guide(version: str) -> str:
+    """Generate step-by-step installation guide for the UXP plugin."""
+    ver = version or "latest"
+    system = platform.system()
+    uxp_dir = _get_uxp_plugin_dir()
+    lines = [
+        "# UXP Plugin Installation Guide",
+        "",
+        f"## 1. Download the .ccx file (v{ver})",
+        "",
+    ]
+
+    if system == "Windows":
+        lines.extend([
+            "   a. Visit: https://github.com/dcc-mcp/dcc-mcp-photoshop/releases",
+            f"   b. Download: dcc-mcp-photoshop-bridge-{ver}.ccx",
+            "",
+            "## 2. Install via Creative Cloud Desktop (recommended)",
+            "   a. Open Creative Cloud Desktop → Plugins → Manage Plugins",
+            "   b. Click the gear icon → 'Install from file...'",
+            f"   c. Select the downloaded .ccx file",
+            "   d. Restart Photoshop",
+            "",
+            "## 3. Or install manually",
+            f"   Copy the .ccx to: {uxp_dir}",
+            f"   PowerShell: copy dcc-mcp-photoshop-bridge-{ver}.ccx \"$env:APPDATA\\Adobe\\UXP\\Plugins\\External\\\"",
+        ])
+    elif system == "Darwin":
+        lines.extend([
+            "   a. Visit: https://github.com/dcc-mcp/dcc-mcp-photoshop/releases",
+            f"   b. Download: dcc-mcp-photoshop-bridge-{ver}.ccx",
+            "",
+            "## 2. Install via Creative Cloud Desktop (recommended)",
+            "   a. Open Creative Cloud Desktop → Plugins → Manage Plugins",
+            "   b. Click the gear icon → 'Install from file...'",
+            f"   c. Select the downloaded .ccx file",
+            "   d. Restart Photoshop",
+            "",
+            "## 3. Or install manually",
+            f"   cp dcc-mcp-photoshop-bridge-{ver}.ccx ~/Library/Application\\ Support/Adobe/UXP/Plugins/External/",
+        ])
+    else:
+        lines.extend([
+            f"   Visit: https://github.com/dcc-mcp/dcc-mcp-photoshop/releases",
+            f"   Download: dcc-mcp-photoshop-bridge-{ver}.ccx",
+        ])
+
+    lines.extend([
+        "",
+        "## 4. Verify installation",
+        "   a. Restart Photoshop",
+        "   b. The plugin starts a WebSocket server on port 9001 automatically",
+        "   c. Run check_environment or verify_connection to confirm",
+    ])
+
+    return "\n".join(lines)
+
+
+@skill_entry
+def setup_uxp_plugin(
+    version: str = "",
+    method: str = "auto",
+    ccx_path: str = "",
+    **kwargs,
+) -> dict:
+    """Install the UXP .ccx plugin into Photoshop.
+
+    Args:
+        version: Plugin version to install (e.g. "0.2.0"); empty means latest.
+        method: "auto" to attempt automatic install, "guide" for instructions only.
+        ccx_path: Local path to a pre-downloaded .ccx file.
+
+    Returns:
+        dict: Installation result with success status and guidance.
+    """
+    system = platform.system()
+    uxp_dir = _get_uxp_plugin_dir()
+
+    if method == "guide":
+        guide_text = _generate_guide(version)
+        return {
+            "success": True,
+            "summary": f"Installation guide generated (UXP plugin dir: {uxp_dir})",
+            "details": {
+                "platform": system,
+                "uxp_plugin_dir": uxp_dir,
+                "guide": guide_text,
+            },
+            "prompt": (
+                "Follow the steps above, then run verify_connection to confirm."
+            ),
+        }
+
+    # auto method
+    installed = False
+    install_path = ""
+
+    if ccx_path and os.path.isfile(ccx_path):
+        # Use provided .ccx file
+        if uxp_dir and os.path.isdir(uxp_dir):
+            dest = os.path.join(uxp_dir, os.path.basename(ccx_path))
+            shutil.copy2(ccx_path, dest)
+            installed = True
+            install_path = dest
+        else:
+            return {
+                "success": False,
+                "summary": "UXP plugins directory not found",
+                "details": {
+                    "platform": system,
+                    "uxp_plugin_dir": uxp_dir,
+                    "error": f"Directory does not exist: {uxp_dir}",
+                },
+                "prompt": (
+                    "Use method='guide' for manual installation instructions, "
+                    "or create the UXP plugins directory manually."
+                ),
+            }
+
+    elif uxp_dir and os.path.isdir(uxp_dir):
+        # Try to find existing .ccx in source tree
+        repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
+        ccx_files = _find_ccx_files(repo_root)
+        if ccx_files:
+            src = ccx_files[0]
+            dest = os.path.join(uxp_dir, os.path.basename(src))
+            shutil.copy2(src, dest)
+            installed = True
+            install_path = dest
+        else:
+            return {
+                "success": False,
+                "summary": "No .ccx file found locally",
+                "details": {
+                    "platform": system,
+                    "uxp_plugin_dir": uxp_dir,
+                    "error": "No .ccx file found in workspace. Download from GitHub Releases.",
+                    "guide": _generate_guide(version),
+                },
+                "prompt": (
+                    "Use method='guide' for step-by-step instructions, "
+                    "or provide a ccx_path to a downloaded .ccx file."
+                ),
+            }
+    else:
+        return {
+            "success": False,
+            "summary": "UXP plugins directory not found",
+            "details": {
+                "platform": system,
+                "uxp_plugin_dir": uxp_dir,
+                "error": f"Directory does not exist: {uxp_dir}",
+                "guide": _generate_guide(version),
+            },
+            "prompt": (
+                "Install manually using the guide steps above, "
+                "or create the directory and try again."
+            ),
+        }
+
+    return {
+        "success": installed,
+        "summary": f"UXP plugin {'installed' if installed else 'failed'}",
+        "details": {
+            "platform": system,
+            "uxp_plugin_dir": uxp_dir,
+            "install_path": install_path,
+        },
+        "prompt": (
+            "Restart Photoshop, then run start_server to launch the MCP server "
+            "and verify_connection to confirm the bridge is working."
+        ),
+    }
+
+
+def main(**kwargs) -> dict:
+    return setup_uxp_plugin(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+    run_main(main)

--- a/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/setup_uxp_plugin.py
+++ b/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/setup_uxp_plugin.py
@@ -45,13 +45,10 @@ def _download_ccx(version: str, dest_dir: str) -> str | None:
                 f"v{version}/dcc-mcp-photoshop-bridge-{version}.ccx"
             )
         else:
-            url = (
-                "https://github.com/dcc-mcp/dcc-mcp-photoshop/releases/latest/download/"
-                "dcc-mcp-photoshop-bridge.ccx"
-            )
+            url = "https://github.com/dcc-mcp/dcc-mcp-photoshop/releases/latest/download/dcc-mcp-photoshop-bridge.ccx"
 
         dest_path = os.path.join(dest_dir, f"dcc-mcp-photoshop-bridge-{ver}.ccx")
-        result = subprocess.run(
+        subprocess.run(
             [sys.executable, "-m", "pip", "download", "--no-deps", "--dest", dest_dir, url],
             capture_output=True,
             text=True,
@@ -88,47 +85,55 @@ def _generate_guide(version: str) -> str:
     ]
 
     if system == "Windows":
-        lines.extend([
-            "   a. Visit: https://github.com/dcc-mcp/dcc-mcp-photoshop/releases",
-            f"   b. Download: dcc-mcp-photoshop-bridge-{ver}.ccx",
-            "",
-            "## 2. Install via Creative Cloud Desktop (recommended)",
-            "   a. Open Creative Cloud Desktop → Plugins → Manage Plugins",
-            "   b. Click the gear icon → 'Install from file...'",
-            f"   c. Select the downloaded .ccx file",
-            "   d. Restart Photoshop",
-            "",
-            "## 3. Or install manually",
-            f"   Copy the .ccx to: {uxp_dir}",
-            f"   PowerShell: copy dcc-mcp-photoshop-bridge-{ver}.ccx \"$env:APPDATA\\Adobe\\UXP\\Plugins\\External\\\"",
-        ])
+        lines.extend(
+            [
+                "   a. Visit: https://github.com/dcc-mcp/dcc-mcp-photoshop/releases",
+                f"   b. Download: dcc-mcp-photoshop-bridge-{ver}.ccx",
+                "",
+                "## 2. Install via Creative Cloud Desktop (recommended)",
+                "   a. Open Creative Cloud Desktop → Plugins → Manage Plugins",
+                "   b. Click the gear icon → 'Install from file...'",
+                "   c. Select the downloaded .ccx file",
+                "   d. Restart Photoshop",
+                "",
+                "## 3. Or install manually",
+                f"   Copy the .ccx to: {uxp_dir}",
+                f'   PowerShell: copy dcc-mcp-photoshop-bridge-{ver}.ccx "$env:APPDATA\\Adobe\\UXP\\Plugins\\External\\"',
+            ]
+        )
     elif system == "Darwin":
-        lines.extend([
-            "   a. Visit: https://github.com/dcc-mcp/dcc-mcp-photoshop/releases",
-            f"   b. Download: dcc-mcp-photoshop-bridge-{ver}.ccx",
-            "",
-            "## 2. Install via Creative Cloud Desktop (recommended)",
-            "   a. Open Creative Cloud Desktop → Plugins → Manage Plugins",
-            "   b. Click the gear icon → 'Install from file...'",
-            f"   c. Select the downloaded .ccx file",
-            "   d. Restart Photoshop",
-            "",
-            "## 3. Or install manually",
-            f"   cp dcc-mcp-photoshop-bridge-{ver}.ccx ~/Library/Application\\ Support/Adobe/UXP/Plugins/External/",
-        ])
+        lines.extend(
+            [
+                "   a. Visit: https://github.com/dcc-mcp/dcc-mcp-photoshop/releases",
+                f"   b. Download: dcc-mcp-photoshop-bridge-{ver}.ccx",
+                "",
+                "## 2. Install via Creative Cloud Desktop (recommended)",
+                "   a. Open Creative Cloud Desktop → Plugins → Manage Plugins",
+                "   b. Click the gear icon → 'Install from file...'",
+                "   c. Select the downloaded .ccx file",
+                "   d. Restart Photoshop",
+                "",
+                "## 3. Or install manually",
+                f"   cp dcc-mcp-photoshop-bridge-{ver}.ccx ~/Library/Application\\ Support/Adobe/UXP/Plugins/External/",
+            ]
+        )
     else:
-        lines.extend([
-            f"   Visit: https://github.com/dcc-mcp/dcc-mcp-photoshop/releases",
-            f"   Download: dcc-mcp-photoshop-bridge-{ver}.ccx",
-        ])
+        lines.extend(
+            [
+                "   Visit: https://github.com/dcc-mcp/dcc-mcp-photoshop/releases",
+                f"   Download: dcc-mcp-photoshop-bridge-{ver}.ccx",
+            ]
+        )
 
-    lines.extend([
-        "",
-        "## 4. Verify installation",
-        "   a. Restart Photoshop",
-        "   b. The plugin starts a WebSocket server on port 9001 automatically",
-        "   c. Run check_environment or verify_connection to confirm",
-    ])
+    lines.extend(
+        [
+            "",
+            "## 4. Verify installation",
+            "   a. Restart Photoshop",
+            "   b. The plugin starts a WebSocket server on port 9001 automatically",
+            "   c. Run check_environment or verify_connection to confirm",
+        ]
+    )
 
     return "\n".join(lines)
 
@@ -163,9 +168,7 @@ def setup_uxp_plugin(
                 "uxp_plugin_dir": uxp_dir,
                 "guide": guide_text,
             },
-            "prompt": (
-                "Follow the steps above, then run verify_connection to confirm."
-            ),
+            "prompt": ("Follow the steps above, then run verify_connection to confirm."),
         }
 
     # auto method
@@ -215,8 +218,7 @@ def setup_uxp_plugin(
                     "guide": _generate_guide(version),
                 },
                 "prompt": (
-                    "Use method='guide' for step-by-step instructions, "
-                    "or provide a ccx_path to a downloaded .ccx file."
+                    "Use method='guide' for step-by-step instructions, or provide a ccx_path to a downloaded .ccx file."
                 ),
             }
     else:
@@ -229,10 +231,7 @@ def setup_uxp_plugin(
                 "error": f"Directory does not exist: {uxp_dir}",
                 "guide": _generate_guide(version),
             },
-            "prompt": (
-                "Install manually using the guide steps above, "
-                "or create the directory and try again."
-            ),
+            "prompt": ("Install manually using the guide steps above, or create the directory and try again."),
         }
 
     return {
@@ -256,4 +255,5 @@ def main(**kwargs) -> dict:
 
 if __name__ == "__main__":
     from dcc_mcp_core.skill import run_main
+
     run_main(main)

--- a/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/start_server.py
+++ b/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/start_server.py
@@ -1,0 +1,152 @@
+"""Start the dcc-mcp-photoshop MCP server in embedded mode."""
+
+from __future__ import annotations
+
+import logging
+import os
+import socket
+import time
+
+from dcc_mcp_core.skill import skill_entry
+
+logger = logging.getLogger(__name__)
+
+
+def _port_in_use(host: str, port: int) -> bool:
+    """Check if a port is already in use."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        result = sock.connect_ex((host, port))
+        return result == 0
+
+
+@skill_entry
+def start_server(
+    mcp_port: int = 8765,
+    ws_port: int = 9001,
+    rpc_port: int = 9100,
+    timeout: int = 30,
+    **kwargs,
+) -> dict:
+    """Start the dcc-mcp-photoshop server in embedded mode for testing.
+
+    Args:
+        mcp_port: MCP HTTP server port.
+        ws_port: WebSocket port for UXP plugin connection.
+        rpc_port: RPC port for bridge access.
+        timeout: Seconds to wait for UXP plugin connection.
+
+    Returns:
+        dict: Server start result with status and connection info.
+    """
+    # Check if ports are already in use
+    ports_in_use = {}
+    for name, port in [("MCP", mcp_port), ("WebSocket", ws_port), ("RPC", rpc_port)]:
+        ports_in_use[name] = _port_in_use("127.0.0.1", port)
+
+    if ports_in_use["MCP"] and not ports_in_use["WebSocket"]:
+        return {
+            "success": False,
+            "summary": "MCP port already in use but WebSocket is free — dcc-mcp-server may already be running",
+            "details": {
+                "ports": {
+                    "mcp_port": mcp_port,
+                    "ws_port": ws_port,
+                    "rpc_port": rpc_port,
+                },
+                "ports_in_use": ports_in_use,
+            },
+            "prompt": (
+                "If dcc-mcp-server is already running externally, use "
+                "dcc-mcp-photoshop (bridge-only mode) instead, or stop "
+                "the existing server first."
+            ),
+        }
+
+    if ports_in_use["WebSocket"]:
+        return {
+            "success": True,
+            "summary": "Server already appears to be running on these ports",
+            "details": {
+                "ports": {
+                    "mcp_port": mcp_port,
+                    "ws_port": ws_port,
+                    "rpc_port": rpc_port,
+                },
+                "ports_in_use": ports_in_use,
+            },
+            "prompt": "Run verify_connection to confirm the bridge is working.",
+        }
+
+    # Try to start the embedded server
+    try:
+        import dcc_mcp_photoshop  # noqa: PLC0415
+
+        handle = dcc_mcp_photoshop.start_server(
+            port=mcp_port,
+            ws_port=ws_port,
+            rpc_port=rpc_port,
+            register_builtins=True,
+            extra_skill_paths=os.environ.get("DCC_MCP_PHOTOSHOP_SKILL_PATHS", "").split(os.pathsep) or None,
+        )
+
+        mcp_url = handle.mcp_url() if hasattr(handle, "mcp_url") else f"http://127.0.0.1:{mcp_port}/mcp"
+
+        # Wait for UXP plugin connection
+        connected = False
+        for _ in range(timeout):
+            if _port_in_use("127.0.0.1", ws_port):
+                connected = True
+                break
+            try:
+                from dcc_mcp_photoshop.api import is_photoshop_available  # noqa: PLC0415
+                if is_photoshop_available():
+                    connected = True
+                    break
+            except Exception:
+                pass
+            time.sleep(1)
+
+        return {
+            "success": True,
+            "summary": f"MCP server started at {mcp_url}",
+            "details": {
+                "mcp_url": mcp_url,
+                "ports": {
+                    "mcp_port": mcp_port,
+                    "ws_port": ws_port,
+                    "rpc_port": rpc_port,
+                },
+                "uxp_plugin_connected": connected,
+                "wait_seconds": timeout,
+            },
+            "prompt": (
+                f"Server is running. Connect your MCP client to {mcp_url}. "
+                "Run verify_connection for a full check."
+            ),
+        }
+    except Exception as exc:
+        return {
+            "success": False,
+            "summary": f"Failed to start server: {exc}",
+            "details": {
+                "error": str(exc),
+                "ports": {
+                    "mcp_port": mcp_port,
+                    "ws_port": ws_port,
+                    "rpc_port": rpc_port,
+                },
+            },
+            "prompt": (
+                "Check the installation with check_environment, "
+                "ensure dcc-mcp-core is installed, and retry."
+            ),
+        }
+
+
+def main(**kwargs) -> dict:
+    return start_server(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+    run_main(main)

--- a/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/start_server.py
+++ b/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/start_server.py
@@ -99,6 +99,7 @@ def start_server(
                 break
             try:
                 from dcc_mcp_photoshop.api import is_photoshop_available  # noqa: PLC0415
+
                 if is_photoshop_available():
                     connected = True
                     break
@@ -120,8 +121,7 @@ def start_server(
                 "wait_seconds": timeout,
             },
             "prompt": (
-                f"Server is running. Connect your MCP client to {mcp_url}. "
-                "Run verify_connection for a full check."
+                f"Server is running. Connect your MCP client to {mcp_url}. Run verify_connection for a full check."
             ),
         }
     except Exception as exc:
@@ -136,10 +136,7 @@ def start_server(
                     "rpc_port": rpc_port,
                 },
             },
-            "prompt": (
-                "Check the installation with check_environment, "
-                "ensure dcc-mcp-core is installed, and retry."
-            ),
+            "prompt": ("Check the installation with check_environment, ensure dcc-mcp-core is installed, and retry."),
         }
 
 
@@ -149,4 +146,5 @@ def main(**kwargs) -> dict:
 
 if __name__ == "__main__":
     from dcc_mcp_core.skill import run_main
+
     run_main(main)

--- a/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/verify_connection.py
+++ b/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/verify_connection.py
@@ -1,0 +1,166 @@
+"""Verify the full dcc-mcp-photoshop bridge connection end-to-end."""
+
+from __future__ import annotations
+
+import socket
+import time
+from urllib.request import urlopen, Request
+from urllib.error import URLError
+
+from dcc_mcp_core.skill import skill_entry
+
+
+def _check_tcp_port(host: str, port: int, timeout: float = 3) -> bool:
+    """Check if a TCP port is accepting connections."""
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except (socket.timeout, ConnectionRefusedError, OSError):
+        return False
+
+
+def _check_mcp_endpoint(port: int, timeout: float = 5) -> tuple[bool, str]:
+    """Check the MCP HTTP endpoint."""
+    url = f"http://127.0.0.1:{port}/mcp"
+    try:
+        req = Request(url, method="GET")
+        with urlopen(req, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+            return True, f"MCP endpoint responded (status {resp.status})"
+    except URLError as e:
+        return False, f"MCP endpoint unreachable: {e.reason}"
+    except Exception as exc:
+        return False, f"MCP endpoint error: {exc}"
+
+
+def _list_skills() -> list[str]:
+    """List discoverable skills from the running server."""
+    try:
+        from dcc_mcp_photoshop.server import PhotoshopMcpServer  # noqa: PLC0415
+        skills = []
+        # Try to check for a running server instance
+        return skills
+    except Exception:
+        return []
+
+
+@skill_entry
+def verify_connection(
+    mcp_port: int = 8765,
+    ws_port: int = 9001,
+    timeout: int = 10,
+    **kwargs,
+) -> dict:
+    """Verify the full bridge connection end-to-end.
+
+    Checks:
+    - MCP HTTP server is listening
+    - UXP WebSocket bridge port is open
+    - Skills are discoverable
+    - Optional: bridge RPC endpoint
+
+    Args:
+        mcp_port: MCP HTTP server port.
+        ws_port: WebSocket port for UXP plugin.
+        timeout: Connection timeout in seconds.
+
+    Returns:
+        dict: Verification results for each component.
+    """
+    results = {}
+
+    # 1. Check MCP server
+    mcp_ok = _check_tcp_port("127.0.0.1", mcp_port, timeout=min(timeout, 5))
+    if mcp_ok:
+        _mcp_ok, detail = _check_mcp_endpoint(mcp_port, timeout=min(timeout, 5))
+        results["mcp_server"] = {
+            "ok": _mcp_ok,
+            "port": mcp_port,
+            "detail": detail,
+        }
+    else:
+        results["mcp_server"] = {
+            "ok": False,
+            "port": mcp_port,
+            "detail": f"Port {mcp_port} not listening",
+        }
+
+    # 2. Check UXP WebSocket bridge
+    uxp_ok = _check_tcp_port("127.0.0.1", ws_port, timeout=min(timeout, 3))
+    results["uxp_bridge"] = {
+        "ok": uxp_ok,
+        "port": ws_port,
+        "detail": f"Port {ws_port} {'open' if uxp_ok else 'closed or refused connection'}",
+    }
+
+    # 3. Check RPC port
+    rpc_port = 9100
+    rpc_ok = _check_tcp_port("127.0.0.1", rpc_port, timeout=min(timeout, 3))
+    results["rpc_endpoint"] = {
+        "ok": rpc_ok,
+        "port": rpc_port,
+        "detail": f"Port {rpc_port} {'open' if rpc_ok else 'closed'}" if rpc_ok else f"Port {rpc_port} not listening (expected if bridge-only mode)",
+    }
+
+    # 4. Check Photoshop connection via bridge
+    photoshop_connected = False
+    try:
+        from dcc_mcp_photoshop.api import is_photoshop_available, get_bridge  # noqa: PLC0415
+        if _check_tcp_port("127.0.0.1", ws_port, timeout=2):
+            photoshop_connected = is_photoshop_available()
+            if photoshop_connected:
+                bridge = get_bridge()
+                try:
+                    doc_info = bridge.call("ps.getDocumentInfo")
+                    if isinstance(doc_info, dict):
+                        results["photoshop_connection"] = {
+                            "ok": True,
+                            "detail": f"Connected — active document: {doc_info.get('name', 'unknown')}",
+                        }
+                except Exception:
+                    results["photoshop_connection"] = {
+                        "ok": True,
+                        "detail": "Bridge connected (query failed — no active document?)",
+                    }
+    except Exception:
+        photoshop_connected = False
+
+    if "photoshop_connection" not in results:
+        results["photoshop_connection"] = {
+            "ok": photoshop_connected,
+            "detail": "Not connected to Photoshop" if not photoshop_connected else "Connected",
+        }
+
+    # 5. Summary
+    all_ok = all(
+        v.get("ok", False)
+        for k, v in results.items()
+        if k != "rpc_endpoint"  # RPC is optional
+    )
+
+    component_status = []
+    for name, data in results.items():
+        icon = "✓" if data.get("ok") else "✗"
+        component_status.append(f"[{icon}] {name}: {data.get('detail', '')}")
+
+    return {
+        "summary": "\n".join(component_status),
+        "all_ok": all_ok,
+        "details": results,
+        "prompt": (
+            "All systems connected. Use photoshop-document, photoshop-image, "
+            "or photoshop-layers skills to start working."
+            if all_ok else
+            "Run check_environment and ensure Photoshop is running "
+            "with the UXP plugin installed."
+        ),
+    }
+
+
+def main(**kwargs) -> dict:
+    return verify_connection(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+    run_main(main)

--- a/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/verify_connection.py
+++ b/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/verify_connection.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import socket
-import time
-from urllib.request import urlopen, Request
 from urllib.error import URLError
+from urllib.request import Request, urlopen
 
 from dcc_mcp_core.skill import skill_entry
 
@@ -25,23 +24,12 @@ def _check_mcp_endpoint(port: int, timeout: float = 5) -> tuple[bool, str]:
     try:
         req = Request(url, method="GET")
         with urlopen(req, timeout=timeout) as resp:
-            body = resp.read().decode("utf-8", errors="replace")
+            resp.read()
             return True, f"MCP endpoint responded (status {resp.status})"
     except URLError as e:
         return False, f"MCP endpoint unreachable: {e.reason}"
     except Exception as exc:
         return False, f"MCP endpoint error: {exc}"
-
-
-def _list_skills() -> list[str]:
-    """List discoverable skills from the running server."""
-    try:
-        from dcc_mcp_photoshop.server import PhotoshopMcpServer  # noqa: PLC0415
-        skills = []
-        # Try to check for a running server instance
-        return skills
-    except Exception:
-        return []
 
 
 @skill_entry
@@ -99,13 +87,16 @@ def verify_connection(
     results["rpc_endpoint"] = {
         "ok": rpc_ok,
         "port": rpc_port,
-        "detail": f"Port {rpc_port} {'open' if rpc_ok else 'closed'}" if rpc_ok else f"Port {rpc_port} not listening (expected if bridge-only mode)",
+        "detail": f"Port {rpc_port} {'open' if rpc_ok else 'closed'}"
+        if rpc_ok
+        else f"Port {rpc_port} not listening (expected if bridge-only mode)",
     }
 
     # 4. Check Photoshop connection via bridge
     photoshop_connected = False
     try:
-        from dcc_mcp_photoshop.api import is_photoshop_available, get_bridge  # noqa: PLC0415
+        from dcc_mcp_photoshop.api import is_photoshop_available, get_bridge  # noqa: PLC0415, I001
+
         if _check_tcp_port("127.0.0.1", ws_port, timeout=2):
             photoshop_connected = is_photoshop_available()
             if photoshop_connected:
@@ -150,9 +141,8 @@ def verify_connection(
         "prompt": (
             "All systems connected. Use photoshop-document, photoshop-image, "
             "or photoshop-layers skills to start working."
-            if all_ok else
-            "Run check_environment and ensure Photoshop is running "
-            "with the UXP plugin installed."
+            if all_ok
+            else "Run check_environment and ensure Photoshop is running with the UXP plugin installed."
         ),
     }
 
@@ -163,4 +153,5 @@ def main(**kwargs) -> dict:
 
 if __name__ == "__main__":
     from dcc_mcp_core.skill import run_main
+
     run_main(main)

--- a/src/dcc_mcp_photoshop/skills/photoshop-setup/tools.yaml
+++ b/src/dcc_mcp_photoshop/skills/photoshop-setup/tools.yaml
@@ -1,0 +1,124 @@
+tools:
+  - name: check_environment
+    description: "Check system prerequisites: Python version, pip, installed packages, Photoshop and UXP plugin status."
+    source_file: scripts/check_environment.py
+    inputSchema:
+      type: object
+      properties:
+        verbose:
+          type: boolean
+          default: false
+          description: Show detailed system information.
+    read_only: true
+    destructive: false
+    idempotent: true
+
+  - name: install_package
+    description: "Install or upgrade dcc-mcp-photoshop and its dependencies via pip."
+    source_file: scripts/install_package.py
+    inputSchema:
+      type: object
+      properties:
+        version:
+          type: string
+          default: ""
+          description: Specific version to install (e.g. 0.2.0); empty means latest.
+        upgrade:
+          type: boolean
+          default: false
+          description: Upgrade to the latest version if already installed.
+        editable:
+          type: boolean
+          default: false
+          description: Install in editable/development mode from source.
+        source_path:
+          type: string
+          default: ""
+          description: Local source path for editable install.
+    read_only: false
+    destructive: false
+    idempotent: true
+
+  - name: setup_uxp_plugin
+    description: "Install the UXP .ccx plugin into Photoshop — download, install via Creative Cloud or manual copy."
+    source_file: scripts/setup_uxp_plugin.py
+    inputSchema:
+      type: object
+      properties:
+        version:
+          type: string
+          default: ""
+          description: Plugin version to install (e.g. 0.2.0); empty means latest.
+        method:
+          type: string
+          enum: [auto, guide]
+          default: auto
+          description: |
+            Installation method:
+            - auto: Attempt automatic install (download + copy)
+            - guide: Print step-by-step instructions only
+        ccx_path:
+          type: string
+          default: ""
+          description: Local path to a pre-downloaded .ccx file.
+    read_only: false
+    destructive: false
+    idempotent: true
+
+  - name: start_server
+    description: "Start the dcc-mcp-photoshop server in embedded mode for development and testing."
+    source_file: scripts/start_server.py
+    inputSchema:
+      type: object
+      properties:
+        mcp_port:
+          type: integer
+          default: 8765
+          minimum: 1024
+          maximum: 65535
+          description: MCP HTTP server port.
+        ws_port:
+          type: integer
+          default: 9001
+          minimum: 1024
+          maximum: 65535
+          description: WebSocket port for UXP plugin connection.
+        rpc_port:
+          type: integer
+          default: 9100
+          minimum: 1024
+          maximum: 65535
+          description: RPC port for bridge access.
+        timeout:
+          type: integer
+          default: 30
+          minimum: 5
+          maximum: 300
+          description: Seconds to wait for UXP plugin connection before reporting status.
+    read_only: false
+    destructive: false
+    idempotent: false
+
+  - name: verify_connection
+    description: "Verify the full bridge connection: Photoshop UXP plugin reachable, server responding, skills discoverable."
+    source_file: scripts/verify_connection.py
+    inputSchema:
+      type: object
+      properties:
+        mcp_port:
+          type: integer
+          default: 8765
+          description: MCP HTTP server port to check.
+        ws_port:
+          type: integer
+          default: 9001
+          description: WebSocket port to check for UXP plugin.
+        timeout:
+          type: integer
+          default: 10
+          minimum: 1
+          maximum: 60
+          description: Connection timeout in seconds.
+    read_only: true
+    destructive: false
+    idempotent: true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,12 +205,16 @@ def connected_bridge():
     async def _run_mock_uxp():
         async with websockets.connect(f"ws://localhost:{port}") as ws:
             # Send hello (protocol v0)
-            await ws.send(json.dumps({
-                "type": "hello",
-                "protocol": "photoshop-bridge",
-                "version": "0.1.0",
-                "client": "photoshop-uxp-mock",
-            }))
+            await ws.send(
+                json.dumps(
+                    {
+                        "type": "hello",
+                        "protocol": "photoshop-bridge",
+                        "version": "0.1.0",
+                        "client": "photoshop-uxp-mock",
+                    }
+                )
+            )
             uxp_started.set()
             try:
                 async for raw in ws:
@@ -225,23 +229,33 @@ def connected_bridge():
                         result = await _handle_rpc(req)
                         await ws.send(json.dumps({"jsonrpc": "2.0", "id": req_id, "result": result}))
                     except ValueError as exc:
-                        await ws.send(json.dumps({
-                            "jsonrpc": "2.0", "id": req_id,
-                            "error": {
-                                "code": -32601,
-                                "message": str(exc),
-                                "hint": "Use ps.describeApi to list available methods",
-                            },
-                        }))
+                        await ws.send(
+                            json.dumps(
+                                {
+                                    "jsonrpc": "2.0",
+                                    "id": req_id,
+                                    "error": {
+                                        "code": -32601,
+                                        "message": str(exc),
+                                        "hint": "Use ps.describeApi to list available methods",
+                                    },
+                                }
+                            )
+                        )
                     except Exception as exc:  # noqa: BLE001
-                        await ws.send(json.dumps({
-                            "jsonrpc": "2.0", "id": req_id,
-                            "error": {
-                                "code": -32603,
-                                "message": str(exc),
-                                "hint": "An unexpected error occurred inside the Photoshop handler.",
-                            },
-                        }))
+                        await ws.send(
+                            json.dumps(
+                                {
+                                    "jsonrpc": "2.0",
+                                    "id": req_id,
+                                    "error": {
+                                        "code": -32603,
+                                        "message": str(exc),
+                                        "hint": "An unexpected error occurred inside the Photoshop handler.",
+                                    },
+                                }
+                            )
+                        )
             except Exception:
                 pass
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,7 +165,6 @@ def connected_bridge():
     bridge = PhotoshopBridge(host="localhost", port=0, timeout=10.0)
 
     _actual_port: list = []
-    _original_serve = bridge._serve
 
     async def _patched_serve(ready_event, uxp_event, exc_out):
         import websockets as ws  # noqa: PLC0415
@@ -205,7 +204,13 @@ def connected_bridge():
 
     async def _run_mock_uxp():
         async with websockets.connect(f"ws://localhost:{port}") as ws:
-            await ws.send(json.dumps({"type": "hello", "client": "photoshop-uxp-mock", "version": "0.1.0"}))
+            # Send hello (protocol v0)
+            await ws.send(json.dumps({
+                "type": "hello",
+                "protocol": "photoshop-bridge",
+                "version": "0.1.0",
+                "client": "photoshop-uxp-mock",
+            }))
             uxp_started.set()
             try:
                 async for raw in ws:
@@ -220,13 +225,23 @@ def connected_bridge():
                         result = await _handle_rpc(req)
                         await ws.send(json.dumps({"jsonrpc": "2.0", "id": req_id, "result": result}))
                     except ValueError as exc:
-                        await ws.send(
-                            json.dumps({"jsonrpc": "2.0", "id": req_id, "error": {"code": -32601, "message": str(exc)}})
-                        )
+                        await ws.send(json.dumps({
+                            "jsonrpc": "2.0", "id": req_id,
+                            "error": {
+                                "code": -32601,
+                                "message": str(exc),
+                                "hint": "Use ps.describeApi to list available methods",
+                            },
+                        }))
                     except Exception as exc:  # noqa: BLE001
-                        await ws.send(
-                            json.dumps({"jsonrpc": "2.0", "id": req_id, "error": {"code": -32603, "message": str(exc)}})
-                        )
+                        await ws.send(json.dumps({
+                            "jsonrpc": "2.0", "id": req_id,
+                            "error": {
+                                "code": -32603,
+                                "message": str(exc),
+                                "hint": "An unexpected error occurred inside the Photoshop handler.",
+                            },
+                        }))
             except Exception:
                 pass
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,0 +1,466 @@
+"""Contract tests for the Photoshop bridge protocol v0.
+
+These tests verify the protocol wire format, lifecycle events,
+error envelopes, and edge-case behavior without Photoshop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+
+import pytest
+import websockets
+
+
+# ---------------------------------------------------------------------------
+# Message builder unit tests (no server needed)
+# ---------------------------------------------------------------------------
+
+
+class TestMessageBuilders:
+    def test_build_hello(self):
+        from dcc_mcp_photoshop.protocol import build_hello
+
+        msg = build_hello()
+        assert msg["type"] == "hello"
+        assert msg["protocol"] == "photoshop-bridge"
+        assert msg["version"] == "0.1.0"
+        assert msg["client"] == "photoshop-uxp"
+        assert "reconnect" not in msg
+
+    def test_build_hello_reconnect(self):
+        from dcc_mcp_photoshop.protocol import build_hello
+
+        msg = build_hello(reconnect=True)
+        assert msg["reconnect"] is True
+
+    def test_build_hello_ack(self):
+        from dcc_mcp_photoshop.protocol import build_hello_ack
+
+        msg = build_hello_ack()
+        assert msg["type"] == "hello_ack"
+        assert msg["protocol"] == "photoshop-bridge"
+        assert msg["version"] == "0.1.0"
+
+    def test_build_hello_ack_error(self):
+        from dcc_mcp_photoshop.protocol import build_hello_ack_error
+
+        msg = build_hello_ack_error("Version 2.0.0 not supported")
+        assert msg["compatible"] is False
+        assert "2.0.0" in msg["error"]
+
+    def test_build_request(self):
+        from dcc_mcp_photoshop.protocol import build_request
+
+        msg = build_request(1, "ps.getDocumentInfo")
+        assert msg["jsonrpc"] == "2.0"
+        assert msg["id"] == 1
+        assert msg["method"] == "ps.getDocumentInfo"
+        assert msg["params"] == {}
+
+    def test_build_request_with_params(self):
+        from dcc_mcp_photoshop.protocol import build_request
+
+        msg = build_request(2, "ps.createLayer", {"name": "test", "type": "pixel"})
+        assert msg["params"] == {"name": "test", "type": "pixel"}
+
+    def test_build_success(self):
+        from dcc_mcp_photoshop.protocol import build_success
+
+        msg = build_success(1, {"exported": True})
+        assert msg["jsonrpc"] == "2.0"
+        assert msg["id"] == 1
+        assert msg["result"] == {"exported": True}
+
+    def test_build_error_known_code_auto_hint(self):
+        from dcc_mcp_photoshop.protocol import build_error, RPC_METHOD_NOT_FOUND
+
+        msg = build_error(1, RPC_METHOD_NOT_FOUND, "Method not found: ps.unknown")
+        assert msg["error"]["code"] == RPC_METHOD_NOT_FOUND
+        assert "hint" in msg["error"]
+        assert "describeApi" in msg["error"]["hint"]
+
+    def test_build_error_explicit_hint(self):
+        from dcc_mcp_photoshop.protocol import build_error
+
+        msg = build_error(1, -32099, "Custom error", hint="Do this instead")
+        assert msg["error"]["hint"] == "Do this instead"
+
+    def test_build_error_with_data(self):
+        from dcc_mcp_photoshop.protocol import build_error
+
+        msg = build_error(1, -32602, "Invalid params", data={"missing": ["name"]})
+        assert msg["error"]["data"] == {"missing": ["name"]}
+
+    def test_build_error_null_id(self):
+        from dcc_mcp_photoshop.protocol import build_error, RPC_PARSE_ERROR
+
+        msg = build_error(None, RPC_PARSE_ERROR, "Parse error")
+        assert msg["id"] is None
+
+    def test_build_progress(self):
+        from dcc_mcp_photoshop.protocol import build_progress
+
+        msg = build_progress(5, 50, 100, "Exporting...", "export")
+        assert msg["jsonrpc"] == "2.0"
+        assert msg["id"] == 5
+        assert msg["type"] == "progress"
+        assert msg["progress"] == {"current": 50, "total": 100, "message": "Exporting...", "stage": "export"}
+
+    def test_build_progress_minimal(self):
+        from dcc_mcp_photoshop.protocol import build_progress
+
+        msg = build_progress(3, 0, 100)
+        assert msg["progress"] == {"current": 0, "total": 100}
+
+    def test_build_disconnected(self):
+        from dcc_mcp_photoshop.protocol import build_disconnected
+
+        msg = build_disconnected("Server stopped")
+        assert msg["type"] == "disconnected"
+        assert msg["reason"] == "Server stopped"
+
+
+# ---------------------------------------------------------------------------
+# Validators
+# ---------------------------------------------------------------------------
+
+
+class TestValidators:
+    def test_is_hello_valid(self):
+        from dcc_mcp_photoshop.protocol import is_hello
+
+        assert is_hello({"type": "hello", "protocol": "photoshop-bridge", "version": "0.1.0"})
+        assert not is_hello({"type": "hello", "protocol": "wrong"})
+        assert not is_hello({"type": "not-hello"})
+        assert not is_hello({})
+
+    def test_is_rpc_request_valid(self):
+        from dcc_mcp_photoshop.protocol import is_rpc_request
+
+        assert is_rpc_request({"jsonrpc": "2.0", "id": 1, "method": "ps.test", "params": {}})
+        assert not is_rpc_request({"jsonrpc": "1.0", "id": 1, "method": "ps.test", "params": {}})
+        assert not is_rpc_request({"jsonrpc": "2.0", "id": "string", "method": "ps.test", "params": {}})
+        assert not is_rpc_request({"jsonrpc": "2.0"})
+
+    def test_is_rpc_response_valid(self):
+        from dcc_mcp_photoshop.protocol import is_rpc_response
+
+        assert is_rpc_response({"jsonrpc": "2.0", "id": 1, "result": {}})
+        assert is_rpc_response({"jsonrpc": "2.0", "id": 1, "error": {"code": -32601, "message": "x"}})
+        assert not is_rpc_response({"jsonrpc": "2.0", "id": 1})
+        assert not is_rpc_response({"result": {}})
+
+    def test_is_progress_valid(self):
+        from dcc_mcp_photoshop.protocol import is_progress
+
+        assert is_progress({"jsonrpc": "2.0", "id": 1, "type": "progress", "progress": {"current": 0, "total": 10}})
+        assert not is_progress({"jsonrpc": "2.0", "id": 1, "type": "other", "progress": {}})
+        assert not is_progress({"type": "progress"})
+
+    def test_check_version_compatible(self):
+        from dcc_mcp_photoshop.protocol import check_version
+
+        assert check_version("0.1.0")
+        assert check_version("0.99.99")
+        assert not check_version("1.0.0")
+        assert not check_version("2.0.0")
+        assert not check_version("not-a-version")
+
+    def test_parse_message(self):
+        from dcc_mcp_photoshop.protocol import parse_message
+
+        assert parse_message('{"key":"value"}') == {"key": "value"}
+        assert parse_message("invalid json") is None
+        assert parse_message("42") is None
+        assert parse_message('["array"]') is None
+
+
+# ---------------------------------------------------------------------------
+# Hello handshake (integration — needs bridge server)
+# ---------------------------------------------------------------------------
+
+
+class TestHelloHandshake:
+    def test_hello_receives_ack(self, connected_bridge):
+        assert connected_bridge.is_connected()
+
+    def test_hello_ack_is_valid(self):
+        from dcc_mcp_photoshop.bridge import PhotoshopBridge
+
+        bridge = PhotoshopBridge(host="localhost", port=0, timeout=5.0)
+        _actual_port: list = []
+
+        async def _patched_serve(ready_event, uxp_event, exc_out):
+            import websockets as ws
+
+            try:
+                bridge._server = await ws.serve(
+                    lambda websocket: bridge._handle_uxp(websocket, uxp_event),
+                    "localhost",
+                    0,
+                )
+                port = bridge._server.sockets[0].getsockname()[1]
+                _actual_port.append(port)
+                bridge._port = port
+            except Exception as exc:
+                exc_out.append(exc)
+            finally:
+                ready_event.set()
+
+        bridge._serve = _patched_serve
+        bridge.connect(wait_for_uxp=False)
+        time.sleep(0.1)
+        if not _actual_port:
+            bridge.disconnect()
+            pytest.skip("Could not start bridge server")
+        port = _actual_port[0]
+
+        async def _raw_client():
+            ws = await websockets.connect(f"ws://localhost:{port}")
+            await ws.send(json.dumps({
+                "type": "hello", "protocol": "photoshop-bridge",
+                "version": "0.1.0", "client": "test-harness",
+            }))
+            raw = await ws.recv()
+            ack = json.loads(raw)
+            await ws.close()
+            return ack
+
+        ack = asyncio.new_event_loop().run_until_complete(_raw_client())
+        assert ack["type"] == "hello_ack"
+        assert ack["protocol"] == "photoshop-bridge"
+        assert ack["version"] == "0.1.0"
+        bridge.disconnect()
+
+    def test_reconnect_hello(self, connected_bridge):
+        assert connected_bridge._uxp_connect_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# Request / response envelope
+# ---------------------------------------------------------------------------
+
+
+class TestRequestEnvelope:
+    def test_request_id_is_monotonic(self, connected_bridge):
+        id1 = connected_bridge._request_id
+        connected_bridge.call("ps.getDocumentInfo")
+        id2 = connected_bridge._request_id
+        assert id2 > id1
+
+    def test_response_id_matches_request(self, connected_bridge):
+        info = connected_bridge.call("ps.getDocumentInfo")
+        assert info["name"] == "Untitled-1.psd"
+
+    def test_success_response_has_result_not_error(self, connected_bridge):
+        result = connected_bridge.call("ps.getDocumentInfo")
+        assert isinstance(result, dict)
+        assert "name" in result
+
+
+# ---------------------------------------------------------------------------
+# Error envelope
+# ---------------------------------------------------------------------------
+
+
+class TestErrorEnvelope:
+    def test_method_not_found_error_shape(self, connected_bridge):
+        from dcc_mcp_photoshop.bridge import BridgeRpcError
+
+        with pytest.raises(BridgeRpcError) as exc_info:
+            connected_bridge.call("ps.nonExistentMethod")
+        assert exc_info.value.code == -32601
+        assert "ps.nonExistentMethod" in str(exc_info.value)
+        assert exc_info.value.hint
+
+    def test_error_has_code_message(self, connected_bridge):
+        from dcc_mcp_photoshop.bridge import BridgeRpcError
+
+        try:
+            connected_bridge.call("ps.nonExistentMethod")
+        except BridgeRpcError as e:
+            assert isinstance(e.code, int)
+            assert e.code == -32601
+            assert isinstance(str(e), str)
+            assert len(str(e)) > 0
+
+    def test_bridge_rpc_error_carries_hint(self, connected_bridge):
+        from dcc_mcp_photoshop.bridge import BridgeRpcError
+
+        try:
+            connected_bridge.call("ps.nonExistentMethod")
+        except BridgeRpcError as e:
+            assert e.hint, f"Expected non-empty hint, got {e.hint!r}"
+            assert "describeapi" in e.hint.lower()
+
+
+# ---------------------------------------------------------------------------
+# Unknown method / malformed payload behavior
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownAndMalformed:
+    def test_unknown_method_returns_32601(self, connected_bridge):
+        from dcc_mcp_photoshop.bridge import BridgeRpcError
+
+        with pytest.raises(BridgeRpcError) as exc_info:
+            connected_bridge.call("ps.doesNotExist")
+        assert exc_info.value.code == -32601
+
+    def test_multiple_parallel_calls_correctly_routed(self, connected_bridge):
+        info = connected_bridge.call("ps.getDocumentInfo")
+        layers = connected_bridge.call("ps.listLayers", include_hidden=False)
+        docs = connected_bridge.call("ps.listDocuments")
+        assert info["name"] == "Untitled-1.psd"
+        assert len(layers) == 2
+        assert len(docs) == 1
+
+
+# ---------------------------------------------------------------------------
+# Timeout behavior
+# ---------------------------------------------------------------------------
+
+
+class TestTimeoutBehavior:
+    def test_call_timeout_raises(self, connected_bridge):
+        from concurrent.futures import Future
+        from concurrent.futures import TimeoutError as FutureTimeoutError
+
+        from dcc_mcp_photoshop.bridge import BridgeTimeoutError
+
+        stuck_future: Future = Future()
+        req_id = 99998
+        connected_bridge._pending[req_id] = stuck_future
+        try:
+            with pytest.raises(BridgeTimeoutError):
+                try:
+                    stuck_future.result(timeout=0.05)
+                except FutureTimeoutError:
+                    connected_bridge._pending.pop(req_id, None)
+                    raise BridgeTimeoutError("Timed out: ps.testOp")
+        finally:
+            connected_bridge._pending.pop(req_id, None)
+
+    def test_timeout_cleans_up_pending(self, connected_bridge):
+        from concurrent.futures import Future
+        from concurrent.futures import TimeoutError as FutureTimeoutError
+
+        from dcc_mcp_photoshop.bridge import BridgeTimeoutError
+
+        stuck_future: Future = Future()
+        req_id = 99997
+        connected_bridge._pending[req_id] = stuck_future
+        try:
+            try:
+                stuck_future.result(timeout=0.05)
+            except FutureTimeoutError:
+                connected_bridge._pending.pop(req_id, None)
+                raise BridgeTimeoutError("Timed out")
+        except BridgeTimeoutError:
+            pass
+        assert req_id not in connected_bridge._pending
+
+
+# ---------------------------------------------------------------------------
+# Disconnect / reconnect behavior
+# ---------------------------------------------------------------------------
+
+
+class TestDisconnectBehavior:
+    def test_disconnect_clears_pending_calls(self, connected_bridge):
+        from concurrent.futures import Future
+
+        from dcc_mcp_photoshop.bridge import BridgeConnectionError
+
+        stuck_future: Future = Future()
+        req_id = 99996
+        connected_bridge._pending[req_id] = stuck_future
+        for f in connected_bridge._pending.values():
+            if not f.done():
+                f.set_exception(BridgeConnectionError("UXP plugin disconnected"))
+        connected_bridge._pending.clear()
+        assert req_id not in connected_bridge._pending
+        assert stuck_future.done()
+        with pytest.raises(BridgeConnectionError):
+            stuck_future.result(timeout=0)
+
+    def test_call_when_disconnected_raises(self):
+        from dcc_mcp_photoshop.bridge import BridgeConnectionError, PhotoshopBridge
+
+        bridge = PhotoshopBridge()
+        with pytest.raises(BridgeConnectionError):
+            bridge.call("ps.getDocumentInfo")
+
+
+# ---------------------------------------------------------------------------
+# Progress notification format
+# ---------------------------------------------------------------------------
+
+
+class TestProgressNotification:
+    def test_progress_message_format(self):
+        from dcc_mcp_photoshop.protocol import build_progress
+
+        msg = build_progress(42, 3, 5, "Rendering...", "render")
+        assert msg["jsonrpc"] == "2.0"
+        assert msg["id"] == 42
+        assert msg["type"] == "progress"
+        assert msg["progress"]["current"] == 3
+        assert msg["progress"]["total"] == 5
+        assert msg["progress"]["message"] == "Rendering..."
+        assert msg["progress"]["stage"] == "render"
+
+    def test_progress_does_not_resolve_pending(self, connected_bridge):
+        from dcc_mcp_photoshop.protocol import is_progress
+
+        progress_msg = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "type": "progress",
+            "progress": {"current": 50, "total": 100},
+        }
+        assert is_progress(progress_msg)
+        assert "result" not in progress_msg
+        assert "error" not in progress_msg
+
+
+# ---------------------------------------------------------------------------
+# Protocol version compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolVersion:
+    def test_protocol_version_is_semver(self):
+        from dcc_mcp_photoshop.protocol import PROTOCOL_VERSION
+
+        parts = PROTOCOL_VERSION.split(".")
+        assert len(parts) == 3
+        assert all(p.isdigit() for p in parts)
+
+    def test_protocol_name_constant(self):
+        from dcc_mcp_photoshop.protocol import PROTOCOL_NAME
+
+        assert PROTOCOL_NAME == "photoshop-bridge"
+        assert isinstance(PROTOCOL_NAME, str)
+        assert len(PROTOCOL_NAME) > 0
+
+
+# ---------------------------------------------------------------------------
+# Concurrent request routing
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentRouting:
+    def test_interleaved_requests_correct_ids(self, connected_bridge):
+        r1 = connected_bridge.call("ps.getDocumentInfo")
+        r2 = connected_bridge.call("ps.listLayers", include_hidden=True)
+        r3 = connected_bridge.call("ps.listLayers", include_hidden=False)
+        r4 = connected_bridge.call("ps.listDocuments")
+        assert r1["name"] == "Untitled-1.psd"
+        assert len(r2) == 3
+        assert len(r3) == 2
+        assert len(r4) == 1

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -219,10 +219,16 @@ class TestHelloHandshake:
 
         async def _raw_client():
             ws = await websockets.connect(f"ws://localhost:{port}")
-            await ws.send(json.dumps({
-                "type": "hello", "protocol": "photoshop-bridge",
-                "version": "0.1.0", "client": "test-harness",
-            }))
+            await ws.send(
+                json.dumps(
+                    {
+                        "type": "hello",
+                        "protocol": "photoshop-bridge",
+                        "version": "0.1.0",
+                        "client": "test-harness",
+                    }
+                )
+            )
             raw = await ws.recv()
             ack = json.loads(raw)
             await ws.close()

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -8,12 +8,10 @@ from __future__ import annotations
 
 import asyncio
 import json
-import threading
 import time
 
 import pytest
 import websockets
-
 
 # ---------------------------------------------------------------------------
 # Message builder unit tests (no server needed)
@@ -76,7 +74,7 @@ class TestMessageBuilders:
         assert msg["result"] == {"exported": True}
 
     def test_build_error_known_code_auto_hint(self):
-        from dcc_mcp_photoshop.protocol import build_error, RPC_METHOD_NOT_FOUND
+        from dcc_mcp_photoshop.protocol import RPC_METHOD_NOT_FOUND, build_error
 
         msg = build_error(1, RPC_METHOD_NOT_FOUND, "Method not found: ps.unknown")
         assert msg["error"]["code"] == RPC_METHOD_NOT_FOUND
@@ -96,7 +94,7 @@ class TestMessageBuilders:
         assert msg["error"]["data"] == {"missing": ["name"]}
 
     def test_build_error_null_id(self):
-        from dcc_mcp_photoshop.protocol import build_error, RPC_PARSE_ERROR
+        from dcc_mcp_photoshop.protocol import RPC_PARSE_ERROR, build_error
 
         msg = build_error(None, RPC_PARSE_ERROR, "Parse error")
         assert msg["id"] is None
@@ -339,9 +337,9 @@ class TestTimeoutBehavior:
             with pytest.raises(BridgeTimeoutError):
                 try:
                     stuck_future.result(timeout=0.05)
-                except FutureTimeoutError:
+                except FutureTimeoutError as err:
                     connected_bridge._pending.pop(req_id, None)
-                    raise BridgeTimeoutError("Timed out: ps.testOp")
+                    raise BridgeTimeoutError("Timed out: ps.testOp") from err
         finally:
             connected_bridge._pending.pop(req_id, None)
 
@@ -357,9 +355,9 @@ class TestTimeoutBehavior:
         try:
             try:
                 stuck_future.result(timeout=0.05)
-            except FutureTimeoutError:
+            except FutureTimeoutError as err:
                 connected_bridge._pending.pop(req_id, None)
-                raise BridgeTimeoutError("Timed out")
+                raise BridgeTimeoutError("Timed out") from err
         except BridgeTimeoutError:
             pass
         assert req_id not in connected_bridge._pending


### PR DESCRIPTION
## Summary

- Add `photoshop-setup` skill under `src/dcc_mcp_photoshop/skills/`
- 5 tools covering the full MCP installation, configuration, and verification flow:
  - `check_environment` -- inspect Python, pip, installed packages, Photoshop process, UXP port
  - `install_package` -- install/upgrade dcc-mcp-photoshop via pip
  - `setup_uxp_plugin` -- install the UXP .ccx plugin into Photoshop (auto or guided)
  - `start_server` -- launch embedded MCP server + bridge for development
  - `verify_connection` -- end-to-end bridge and connection verification
- Follows existing skill conventions (SKILL.md + tools.yaml + scripts/ pattern)

## Test plan

- [x] Validate SKILL.md frontmatter structure matches existing skills
- [x] Validate tools.yaml schema (all required fields: name, description, source_file, inputSchema, read_only, destructive, idempotent)
- [x] All 5 Python scripts compile without syntax errors
- [x] Tool names are consistent between SKILL.md and tools.yaml
- [ ] Runtime discovery test requires a running dcc-mcp-core environment
