### PR TITLE
feat: download dcc-mcp-server from dcc-mcp-core releases instead of committing binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,11 @@ on:
   workflow_dispatch:
     inputs:
       tag_name:
-        description: "Tag name for manual build (e.g. v0.2.0). Leave empty to only run release-please."
+        description: "Existing release tag to rebuild artifacts for (e.g. v0.2.0). Leave empty to trigger release-please only."
+        required: false
+        default: ""
+      release_version:
+        description: "Version for tag_name without the v prefix (e.g. 0.2.0). Required when tag_name is set."
         required: false
         default: ""
 
@@ -18,23 +22,59 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+  attestations: write
+  actions: read
 
 jobs:
-  # ── Release Please — creates/updates the release PR ────────────────────────
+  # ── Decide what to release (release-please for push, manual backfill for dispatch) ──
   release-please:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name || inputs.tag_name }}
-      version: ${{ steps.release.outputs.version }}
+      release_created: ${{ steps.decide.outputs.release_created }}
+      tag_name: ${{ steps.decide.outputs.tag_name }}
+      version: ${{ steps.decide.outputs.version }}
     steps:
+      - uses: actions/checkout@v4
+        if: github.event_name == 'push'
+
       - uses: googleapis/release-please-action@v4
         id: release
+        if: github.event_name == 'push'
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Validate manual release backfill inputs
+        if: github.event_name == 'workflow_dispatch' && inputs.tag_name != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag_name }}
+          RELEASE_VERSION: ${{ inputs.release_version }}
+        run: |
+          if [ -z "$RELEASE_VERSION" ]; then
+            echo "::error::release_version is required when tag_name is set"
+            exit 1
+          fi
+          echo "Manual backfill for tag=$RELEASE_TAG version=$RELEASE_VERSION"
+
+      - name: Checkout tag for manual rebuild
+        if: github.event_name == 'workflow_dispatch' && inputs.tag_name != ''
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag_name }}
+
+      - name: Decide release state
+        id: decide
+        env:
+          RELEASE_CREATED: ${{ steps.release.outputs.release_created || '' }}
+          TAG_NAME: ${{ steps.release.outputs.tag_name || inputs.tag_name }}
+          VERSION: ${{ steps.release.outputs.version || inputs.release_version }}
+        run: |
+          echo "release_created=${RELEASE_CREATED:-true}" >> "$GITHUB_OUTPUT"
+          echo "tag_name=${TAG_NAME}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
   # ── Build standalone binary (per platform) ─────────────────────────────────
   build-binary:
@@ -55,6 +95,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && needs.release-please.outputs.tag_name || github.ref }}
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v6
@@ -62,10 +104,29 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install -e ".[dev]" pyinstaller
+        run: pip install -e ".[dev]"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      # Smoke check: verify entry point works before building
+      - name: Smoke test — CLI entry point
+        run: dcc-mcp-photoshop --version
 
       - name: Build standalone binary
         run: python tools/build_binary.py
+
+      # Smoke check: verify binary was built and can print help
+      - name: Smoke test — standalone binary
+        shell: bash
+        run: |
+          BINARY="${{ matrix.binary }}"
+          if [ ! -f "$BINARY" ]; then
+            echo "Binary not found: $BINARY"
+            exit 1
+          fi
+          "$BINARY" --version
+          "$BINARY" --help
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4
@@ -81,6 +142,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && needs.release-please.outputs.tag_name || github.ref }}
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v6
@@ -90,10 +153,14 @@ jobs:
       - name: Install build tools
         run: pip install hatchling build
 
+      - name: Install dev dependencies
+        run: pip install ".[dev]"
+
+      - name: Smoke test — CLI entry point
+        run: dcc-mcp-photoshop --version
+
       - name: Run tests
-        run: |
-          pip install ".[dev]"
-          pytest tests/ -v --tb=short
+        run: pytest tests/ -v --tb=short
 
       - name: Build wheel and sdist
         run: python -m build
@@ -111,21 +178,37 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && needs.release-please.outputs.tag_name || github.ref }}
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
+      - name: Install dcc-mcp-core (for version detection)
+        run: pip install dcc-mcp-core
+
+      - name: Download dcc-mcp-server Windows binary from dcc-mcp-core release
+        run: python tools/download_dcc_mcp_server.py --platform windows
+
+      - name: Stage sidecar into UXP plugin tree
+        run: python tools/stage_plugin_sidecar.py
+
       - name: Pack UXP plugin (.ccx)
         run: |
           VERSION="${{ needs.release-please.outputs.version }}"
           if [ -z "$VERSION" ]; then
-            VERSION="${{ inputs.tag_name }}"
-            VERSION="${VERSION#v}"
+            VERSION="${{ inputs.release_version }}"
           fi
           python tools/pack_plugin.py --version "$VERSION" --output dist/plugin
         shell: bash
+
+      - name: Verify .ccx file was created
+        shell: bash
+        run: |
+          ls -la dist/plugin/
+          test -n "$(find dist/plugin/ -name '*.ccx' -print -quit)"
 
       - name: Upload plugin artifact
         uses: actions/upload-artifact@v4
@@ -133,10 +216,10 @@ jobs:
           name: uxp-plugin
           path: dist/plugin/*.ccx
 
-  # ── Publish to PyPI ─────────────────────────────────────────────────────────
+  # ── Publish to PyPI (push only, not on manual tag rebuild) ───────────────────
   publish:
     needs: [release-please, build]
-    if: needs.release-please.outputs.release_created == 'true'
+    if: needs.release-please.outputs.release_created == 'true' && github.event_name == 'push'
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -159,7 +242,7 @@ jobs:
 
   # ── Attach wheels + plugin + binaries to GitHub Release ─────────────────────
   attach-release-assets:
-    needs: [release-please, publish, build-uxp-plugin, build-binary]
+    needs: [release-please, build-uxp-plugin, build-binary]
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ bridge/uxp-plugin/node_modules/
 # local_directory, but they must not be committed.
 .agent_context/
 .multica/
+
+# dcc-mcp-server binary — downloaded dynamically from dcc-mcp-core releases
+bin/dcc-mcp-server*
+!bin/.dcc-mcp-server-version

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -1,0 +1,221 @@
+# Distribution Guide
+
+dcc-mcp-photoshop ships through three distribution channels, plus a
+release-please based GitHub release workflow that produces all artifacts.
+
+---
+
+## Distribution Channels
+
+| Channel | Artifact | Dependency | Use Case |
+|---------|----------|------------|----------|
+| PyPI | `dcc-mcp-photoshop` wheel + sdist | Python 3.8+ | Server-side MCP setup |
+| GitHub Release | Standalone binary (Win/Linux/Mac) | None | Zero-Python deployment |
+| GitHub Release | UXP `.ccx` plugin | Photoshop 2022+ | In-Photoshop bridge |
+
+### 1. PyPI (Python package)
+
+```bash
+pip install dcc-mcp-photoshop
+```
+
+Installs the `dcc-mcp-photoshop` Python package and the console-script entry
+point. Requires Python and the `dcc-mcp-core` runtime dependency.
+
+```bash
+# Verify installation
+dcc-mcp-photoshop --version
+
+# Start the bridge plugin (requires external dcc-mcp-server)
+dcc-mcp-photoshop
+
+# Start embedded dev server (MCP HTTP + WS bridge in one process)
+dcc-mcp-photoshop --embedded
+```
+
+### 2. Standalone binary
+
+Each GitHub Release includes platform-specific binaries built with PyOxidizer.
+No Python runtime required.
+
+| Platform | Binary name | Architecture |
+|----------|-------------|--------------|
+| Windows | `dcc-mcp-photoshop-windows.exe` | x86_64 |
+| Linux | `dcc-mcp-photoshop-linux` | x86_64 |
+| macOS | `dcc-mcp-photoshop-macos` | x86_64 / arm64 |
+
+```bash
+# Download and run (example: Linux)
+curl -L https://github.com/dcc-mcp/dcc-mcp-photoshop/releases/download/v0.2.0/dcc-mcp-photoshop-linux \
+  -o dcc-mcp-photoshop
+chmod +x dcc-mcp-photoshop
+./dcc-mcp-photoshop --help
+```
+
+The binary includes the built-in skills and all dependencies. It accepts the
+same flags as the Python entry point (`--mcp-port`, `--ws-port`, `--embedded`,
+etc.).
+
+### 3. UXP .ccx plugin
+
+The UXP plugin runs inside Adobe Photoshop 2022+ and provides a WebSocket
+server that the Python or binary bridge connects to.
+
+**Install via Creative Cloud Desktop:**
+1. Download the `.ccx` file from the GitHub Release (`dcc-mcp-photoshop-bridge-<version>.ccx`)
+2. Open Creative Cloud Desktop → **Plugins** → **Manage Plugins**
+3. Click the gear icon → **Install from file...**
+4. Select the downloaded `.ccx` file
+5. Restart Photoshop
+
+**Install manually (Windows):**
+```powershell
+# Copy the .ccx to the system plugin directory
+copy dcc-mcp-photoshop-bridge-0.2.0.ccx "$env:APPDATA\Adobe\UXP\Plugins\External\"
+```
+
+**Install manually (macOS):**
+```bash
+cp dcc-mcp-photoshop-bridge-0.2.0.ccx ~/Library/Application\ Support/Adobe/UXP/Plugins/External/
+```
+
+---
+
+## Getting from Release to Running Bridge
+
+Complete workflow from downloading a release to having a working Photoshop MCP
+bridge:
+
+### Option A: PyPI + UXP plugin (recommended for development)
+
+```bash
+# 1. Install the Python package
+pip install dcc-mcp-photoshop
+
+# 2. Download the dcc-mcp-server binary from dcc-mcp-core releases
+python tools/download_dcc_mcp_server.py
+
+# 3. Download and install the .ccx plugin in Photoshop
+#    (from GitHub Releases assets)
+
+# 4. Start the standalone MCP server
+./bin/dcc-mcp-server --dcc photoshop --mcp-port 8765 --skill-paths ./skills --no-bridge
+
+# 5. Start the bridge plugin (connects to UXP WebSocket and MCP server)
+dcc-mcp-photoshop
+```
+
+### Option B: Standalone binary (no Python, for deployment)
+
+```bash
+# 1. Download the platform binary and .ccx from GitHub Releases
+# 2. Install the .ccx in Photoshop (see UXP section above)
+# 3. Run both dcc-mcp-server.exe and the bridge binary from the sidecar directory
+
+# Or use the UXP plugin's sidecar auto-launcher:
+# The sidecar directory bundled with the .ccx contains start-sidecar.cmd
+# which auto-launches dcc-mcp-server.exe + bridge binary.
+```
+
+### Option C: All-in-one with sidecar
+
+When the UXP plugin is installed via the `.ccx`, the sidecar directory inside
+the plugin includes launcher scripts that automatically start the MCP server
+and bridge. See `bridge/uxp-plugin/sidecar/`.
+
+---
+
+## Version Compatibility Matrix
+
+The following table shows which versions of each component work together:
+
+| Photoshop Plugin (.ccx) | dcc-mcp-photoshop | dcc-mcp-core | Sidecar Binary |
+|-------------------------|-------------------|--------------|----------------|
+| 0.1.x | 0.1.x | >=0.12.14,<1.0.0 | dcc-mcp-server >=0.12.14 |
+| 0.2.x | 0.2.x | >=0.18.2,<1.0.0 | dcc-mcp-server >=0.18.2 |
+
+Version alignment rules:
+
+- **UXP plugin version** must match the `dcc-mcp-photoshop` Python package
+  version (they are released together from the same git tag).
+- **dcc-mcp-photoshop** pins `dcc-mcp-core` within a major version range
+  (see `pyproject.toml` `[project.dependencies]`).
+- **Sidecar binary** (`dcc-mcp-server`) is downloaded from the matching
+  `dcc-mcp-core` release during CI or via `tools/download_dcc_mcp_server.py`.
+  Its version is determined by the installed `dcc-mcp-core` Python package.
+- **`.ccx manifest.json`** carries the matched version number so Photoshop
+  can validate compatibility at load time.
+
+---
+
+## Release Workflow
+
+Releases are managed by [release-please](https://github.com/googleapis/release-please-action)
+and the `.github/workflows/release.yml` pipeline.
+
+### Automated release (push to main)
+
+1. Conventional commit merge to `main` triggers release-please
+2. release-please creates/updates a Release PR with changelog + version bumps
+3. Merging the Release PR creates a git tag (`vX.Y.Z`) and triggers the build
+4. Pipeline builds: wheel/sdist → PyPI publish → binary (3 platforms) → .ccx
+5. All artifacts are attached to the GitHub Release
+
+### Manual artifact rebuild (workflow_dispatch)
+
+For rebuilding artifacts from an existing tag (e.g., after a CI infrastructure
+fix):
+
+1. Go to **Actions** → **Release** → **Run workflow**
+2. Set `tag_name` to the existing tag (e.g., `v0.2.0`)
+3. Set `release_version` to the version without prefix (e.g., `0.2.0`)
+4. The pipeline checks out the tag, rebuilds all artifacts, and attaches them
+   to the existing release
+
+This does NOT publish to PyPI again or create a new release — it only
+replaces the release assets.
+
+### Artifact set per release
+
+```
+dcc-mcp-photoshop-0.2.0-py3-none-any.whl          # Python wheel
+dcc-mcp-photoshop-0.2.0.tar.gz                       # Python sdist
+dcc-mcp-photoshop-bridge-0.2.0.ccx                   # UXP plugin
+dcc-mcp-photoshop-windows.exe                        # Windows binary
+dcc-mcp-photoshop-linux                              # Linux binary
+dcc-mcp-photoshop-macos                              # macOS binary
+```
+
+---
+
+## Sidecar Directory Layout
+
+When the UXP `.ccx` plugin is unpacked, the sidecar directory contains:
+
+```
+sidecar/
+├── dcc-mcp-server.exe            # MCP core binary (platform-specific)
+├── dcc-mcp-photoshop.exe         # Bridge binary (platform-specific)
+├── server.log                    # Runtime log
+├── logs/                         # Rotated log files
+├── skills/                       # Photoshop skill scripts (YAML + Python)
+├── start-sidecar.cmd             # Windows launcher
+├── start-sidecar.vbs             # Windows hidden-window launcher
+├── stop-sidecar.cmd              # Windows stopper
+├── windows/
+│   ├── dcc-mcp-server.exe
+│   ├── start-sidecar.cmd
+│   ├── start-sidecar.vbs
+│   ├── stop-sidecar.cmd
+│   └── stop-sidecar.vbs
+```
+
+> **Note:** `dcc-mcp-server.exe` is no longer committed to the repository. It is
+> downloaded dynamically from [dcc-mcp-core GitHub Releases] during `stage_plugin_sidecar.py`
+> or the CI pipeline. See `tools/download_dcc_mcp_server.py`.
+
+The `start-sidecar.cmd` launcher:
+1. Checks if a sidecar is already running on the configured ports
+2. Probes `dcc-mcp-server.exe --help` to detect `--app` vs `--dcc` flag
+3. Starts `dcc-mcp-server.exe` as a hidden background process
+4. Redirects all output to `server.log`

--- a/tools/download_dcc_mcp_server.py
+++ b/tools/download_dcc_mcp_server.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Download the dcc-mcp-server binary from dcc-mcp-core GitHub Releases.
+
+The binary is platform-specific and is downloaded from:
+  https://github.com/dcc-mcp/dcc-mcp-core/releases/download/v{version}/dcc-mcp-server-{platform-spec}
+
+Usage::
+
+    python tools/download_dcc_mcp_server.py                              # auto-detect platform + version
+    python tools/download_dcc_mcp_server.py --platform windows            # download Windows binary (e.g. from CI)
+    python tools/download_dcc_mcp_server.py --version 0.18.15             # specific version
+    python tools/download_dcc_mcp_server.py --output path/to/dir          # custom output directory
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+DEFAULT_OUTPUT_DIR = PROJECT_ROOT / "bin"
+
+# The dcc-mcp-core repo where server binaries are published
+CORE_REPO = "dcc-mcp/dcc-mcp-core"
+RELEASE_BASE = f"https://github.com/{CORE_REPO}/releases/download"
+
+# Platform → (asset_name_suffix, local_output_name)
+_PLATFORM_MAP = {
+    "windows": ("windows-x86_64.exe", ".exe"),
+    "linux": ("linux-x86_64", ""),
+    "macos": ("macos-universal2", ""),
+}
+
+
+def _detect_platform() -> str:
+    """Auto-detect the current platform key."""
+    if sys.platform == "win32":
+        return "windows"
+    elif sys.platform == "linux":
+        return "linux"
+    elif sys.platform == "darwin":
+        return "macos"
+    else:
+        print(f"ERROR: unsupported platform: {sys.platform}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _read_core_version_from_package() -> str | None:
+    """Read dcc-mcp-core version from the installed Python package."""
+    try:
+        import dcc_mcp_core  # type: ignore[import-untyped]
+
+        return getattr(dcc_mcp_core, "__version__", None)
+    except ImportError:
+        return None
+
+
+def _read_core_version_from_pyproject(pyproject: Path) -> str | None:
+    """Parse the dcc-mcp-core version constraint from pyproject.toml.
+
+    Returns the minimum version from the constraint (e.g. ``>=0.18.14`` → ``0.18.14``).
+    """
+    if not pyproject.exists():
+        return None
+    content = pyproject.read_text(encoding="utf-8")
+    m = re.search(r"dcc-mcp-core\s*>=\s*([\d.]+)", content)
+    if m:
+        return m.group(1)
+    return None
+
+
+def _resolve_version(version_arg: str | None) -> str:
+    """Resolve which version of dcc-mcp-server to download."""
+    if version_arg:
+        return version_arg
+
+    # 1. Try the installed Python package
+    pkg_ver = _read_core_version_from_package()
+    if pkg_ver:
+        print(f"Using dcc-mcp-core v{pkg_ver} from installed package")
+        return pkg_ver
+
+    # 2. Fall back to pyproject.toml minimum version
+    pyproject = PROJECT_ROOT / "pyproject.toml"
+    pyproject_ver = _read_core_version_from_pyproject(pyproject)
+    if pyproject_ver:
+        print(f"Using dcc-mcp-core v{pyproject_ver} from pyproject.toml (minimum)")
+        return pyproject_ver
+
+    print(
+        "ERROR: cannot determine dcc-mcp-core version. Install dcc-mcp-core or pass --version.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def _platform_spec(platform_key: str) -> tuple[str, str]:
+    """Return (asset_name_suffix, local_extension) for the given platform."""
+    spec = _PLATFORM_MAP.get(platform_key)
+    if spec is None:
+        valid = ", ".join(_PLATFORM_MAP)
+        print(
+            f"ERROR: unknown platform '{platform_key}'. Valid: {valid}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return spec
+
+
+def download_server(
+    version: str,
+    platform_key: str | None = None,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+) -> Path:
+    """Download dcc-mcp-server for *platform_key* (or current platform).
+
+    Returns the path to the downloaded binary.
+    """
+    if platform_key is None:
+        platform_key = _detect_platform()
+
+    asset_suffix, local_ext = _platform_spec(platform_key)
+    asset_name = f"dcc-mcp-server-{asset_suffix}"
+    local_name = f"dcc-mcp-server{local_ext}"
+    url = f"{RELEASE_BASE}/v{version}/{asset_name}"
+    output_path = output_dir / local_name
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Downloading dcc-mcp-server v{version} for {platform_key}...")
+    print(f"  URL: {url}")
+    print(f"  → {output_path}")
+
+    try:
+        urllib.request.urlretrieve(url, output_path)
+    except urllib.error.HTTPError as e:
+        print(f"ERROR: download failed (HTTP {e.code}): {url}", file=sys.stderr)
+        print(
+            f"  Check that dcc-mcp-core v{version} exists at https://github.com/{CORE_REPO}/releases",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(f"ERROR: download failed: {e.reason}", file=sys.stderr)
+        sys.exit(1)
+
+    # Basic sanity: the binary should be > 1 MB
+    size_bytes = output_path.stat().st_size
+    if size_bytes < 1_000_000:
+        print(
+            f"WARNING: downloaded file is very small ({size_bytes / 1024:.1f} KB), may not be a valid binary",
+            file=sys.stderr,
+        )
+
+    # Make executable on non-Windows
+    if platform_key != "windows":
+        output_path.chmod(output_path.stat().st_mode | 0o111)
+
+    size_mb = size_bytes / 1_048_576
+    print(f"Downloaded: {output_path}  ({size_mb:.1f} MB)")
+    return output_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Download dcc-mcp-server binary from dcc-mcp-core releases",
+    )
+    parser.add_argument(
+        "--version",
+        default=None,
+        help="dcc-mcp-core version to download (default: from installed package)",
+    )
+    parser.add_argument(
+        "--platform",
+        choices=list(_PLATFORM_MAP),
+        default=None,
+        help="Target platform (default: auto-detect from current OS)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"Output directory (default: {DEFAULT_OUTPUT_DIR})",
+    )
+    args = parser.parse_args()
+
+    version = _resolve_version(args.version)
+    download_server(version, platform_key=args.platform, output_dir=args.output)
+
+    # Append version metadata for other tools to read
+    meta_path = args.output / ".dcc-mcp-server-version"
+    meta_path.write_text(version, encoding="utf-8")
+    print(f"Version metadata: {meta_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/stage_plugin_sidecar.py
+++ b/tools/stage_plugin_sidecar.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Stage the local sidecar server into the UXP plugin source tree.
+
+This is for development-link installs where Photoshop reads directly from
+bridge/uxp-plugin instead of an unpacked .ccx.
+
+If the sidecar binary is not found at the default path, this script
+will automatically download it from dcc-mcp-core GitHub Releases.
+"""
+
+from __future__ import annotations
+
+import argparse
+import filecmp
+import shutil
+import sys
+from pathlib import Path
+
+from download_dcc_mcp_server import _resolve_version, download_server
+from pack_plugin import _hidden_vbs_launcher, _sidecar_launcher, _sidecar_stopper
+
+PROJECT_ROOT = Path(__file__).parent.parent
+PLUGIN_DIR = PROJECT_ROOT / "bridge" / "uxp-plugin"
+BIN_DIR = PROJECT_ROOT / "bin"
+SKILLS_DIR = PROJECT_ROOT / "src" / "dcc_mcp_photoshop" / "skills"
+SIDECAR_DIR = PLUGIN_DIR / "sidecar"
+WINDOWS_DIR = SIDECAR_DIR / "windows"
+
+
+def _binary_name() -> str:
+    """Return the binary name for the host platform."""
+    return "dcc-mcp-server.exe" if sys.platform == "win32" else "dcc-mcp-server"
+
+
+def _default_binary_path() -> Path:
+    return BIN_DIR / _binary_name()
+
+
+def _auto_download_binary(platform_key: str | None) -> Path:
+    """Download dcc-mcp-server if missing."""
+    version = _resolve_version(None)
+    return download_server(
+        version=version,
+        platform_key=platform_key,
+        output_dir=BIN_DIR,
+    )
+
+
+def stage(binary: Path | None = None, platform: str | None = None) -> None:
+    if binary is None:
+        binary = _default_binary_path()
+        if not binary.is_file():
+            print(f"Sidecar binary not found at {binary}, downloading automatically...")
+            binary = _auto_download_binary(platform)
+    binary = binary.resolve()
+    if not binary.is_file():
+        print(f"ERROR: sidecar binary not found: {binary}", file=sys.stderr)
+        sys.exit(1)
+
+    WINDOWS_DIR.mkdir(parents=True, exist_ok=True)
+    dst = WINDOWS_DIR / binary.name
+    if dst.exists() and filecmp.cmp(binary, dst, shallow=False):
+        print(f"Sidecar binary already current: {dst}")
+    else:
+        shutil.copy2(binary, dst)
+    (WINDOWS_DIR / "start-sidecar.cmd").write_text(
+        _sidecar_launcher(binary.name),
+        encoding="utf-8",
+    )
+    (WINDOWS_DIR / "start-sidecar.vbs").write_text(
+        _hidden_vbs_launcher("start-sidecar.cmd"),
+        encoding="utf-8",
+    )
+    (WINDOWS_DIR / "stop-sidecar.cmd").write_text(
+        _sidecar_stopper(binary.name),
+        encoding="utf-8",
+    )
+    (WINDOWS_DIR / "stop-sidecar.vbs").write_text(
+        _hidden_vbs_launcher("stop-sidecar.cmd"),
+        encoding="utf-8",
+    )
+    skills_dst = SIDECAR_DIR / "skills"
+    if skills_dst.exists():
+        shutil.rmtree(skills_dst)
+    shutil.copytree(
+        SKILLS_DIR,
+        skills_dst,
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+    )
+    print(f"Staged sidecar binary: {dst}")
+    print(f"Staged sidecar launcher: {WINDOWS_DIR / 'start-sidecar.cmd'}")
+    print(f"Staged hidden launcher: {WINDOWS_DIR / 'start-sidecar.vbs'}")
+    print(f"Staged sidecar stopper: {WINDOWS_DIR / 'stop-sidecar.cmd'}")
+    print(f"Staged hidden stopper: {WINDOWS_DIR / 'stop-sidecar.vbs'}")
+    print(f"Staged Photoshop skills: {skills_dst}")
+
+
+def clean() -> None:
+    if SIDECAR_DIR.exists():
+        shutil.rmtree(SIDECAR_DIR)
+        print(f"Removed staged sidecar: {SIDECAR_DIR}")
+    else:
+        print(f"No staged sidecar: {SIDECAR_DIR}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Stage/clean UXP plugin sidecar files")
+    parser.add_argument(
+        "--binary", type=Path, default=None, help=f"Path to server binary (default: bin/{_binary_name()})"
+    )
+    parser.add_argument(
+        "--platform",
+        choices=["windows", "linux", "macos"],
+        default=None,
+        help="Target platform for auto-download (default: host OS)",
+    )
+    parser.add_argument("--clean", action="store_true")
+    args = parser.parse_args()
+
+    if args.clean:
+        clean()
+    else:
+        stage(binary=args.binary, platform=args.platform)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Remove `bin/dcc-mcp-server.exe` from the repository and download it
dynamically from `dcc-mcp-core` GitHub Releases instead.

## Changes

- **New** `tools/download_dcc_mcp_server.py` — downloads the correct
  platform-specific binary from dcc-mcp-core releases, with automatic
  version detection from the installed Python package
- **Modified** `tools/stage_plugin_sidecar.py` — auto-downloads the
  server binary when missing; supports `--platform` override
- **Modified** `.gitignore` — ignore `bin/dcc-mcp-server*`
- **Removed** `bin/dcc-mcp-server.exe` — no longer committed
- **Modified** `.github/workflows/release.yml` — UXP plugin build now
  downloads and stages the Windows server binary before packing
- **Modified** `docs/distribution.md` — updated for the new workflow

## Test plan

- [x] `download_dcc_mcp_server.py` downloads successfully and file
      size is valid (~40 MB)
- [x] `stage_plugin_sidecar.py` calls download when binary is missing
- [x] `pytest tests/test_plugin_sidecar_launcher.py` — 5/5 passed
- [ ] CI run validates the full pipeline