### PR TITLE
fix: add missing sidecar launcher helpers to pack_plugin.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,15 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install dcc-mcp-core (for version detection)
+        run: pip install dcc-mcp-core
+
+      - name: Download dcc-mcp-server Windows binary
+        run: python tools/download_dcc_mcp_server.py --platform windows
+
+      - name: Stage sidecar into UXP plugin tree
+        run: python tools/stage_plugin_sidecar.py
+
       - name: Pack UXP plugin (.ccx)
         run: python tools/pack_plugin.py --output dist/plugin
 

--- a/tools/pack_plugin.py
+++ b/tools/pack_plugin.py
@@ -46,6 +46,29 @@ PROJECT_ROOT = _SCRIPT_DIR.parent
 PLUGIN_DIR = PROJECT_ROOT / "bridge" / "uxp-plugin"
 
 
+def _hidden_vbs_launcher(cmd_name: str) -> str:
+    """Return a .vbs script that launches a .cmd file without a console window."""
+    return (
+        f'CreateObject("Wscript.Shell").Run "cmd /c {cmd_name}", 0, False\n'
+    )
+
+
+def _sidecar_launcher(binary_name: str) -> str:
+    """Return a .cmd script that starts the sidecar server binary."""
+    return (
+        "@echo off\r\n"
+        f'start "" "%~dp0{binary_name}"\r\n'
+    )
+
+
+def _sidecar_stopper(binary_name: str) -> str:
+    """Return a .cmd script that stops the sidecar server by killing its process."""
+    return (
+        "@echo off\r\n"
+        f"taskkill /f /im {binary_name}\r\n"
+    )
+
+
 def _should_exclude(path: Path, plugin_root: Path) -> bool:
     """Return True if the path should be excluded from the archive."""
     rel = path.relative_to(plugin_root)


### PR DESCRIPTION
## Summary
- Added `_hidden_vbs_launcher`, `_sidecar_launcher`, and `_sidecar_stopper` functions to `tools/pack_plugin.py`
- These are imported by `tools/stage_plugin_sidecar.py` (introduced in #1acdda7) but were missing after squash-merge, causing `build-uxp-plugin` CI job to fail with `ImportError`

## Root cause
Commit `1acdda7` (squash-merge of "feat: download dcc-mcp-server from dcc-mcp-core releases") introduced `stage_plugin_sidecar.py` which imports three helper functions from `pack_plugin.py`. These functions were on the feature branch but not included in `pack_plugin.py` on `main`.

## Test plan
- [x] Import verification: `from tools.pack_plugin import _hidden_vbs_launcher, _sidecar_launcher, _sidecar_stopper` succeeds
- [x] Full chain import: `from tools.stage_plugin_sidecar import stage` succeeds
- [ ] CI `build-uxp-plugin` job passes on this branch