### PR TITLE
fix: add missing _write_bridge_url_to_config and _remove_bridge_config to api.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+default_language_version:
+  python: python3.12
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: no-commit-to-branch
+        args: ["--branch", "main"]
+      - id: check-yaml
+        args: ["--unsafe"]
+      - id: check-toml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  # Python lint + format (ruff) — mirrors CI Lint job
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.16
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The bundled sidecar starts automatically and listens on the following ports. MCP
 {
   "mcpServers": {
     "photoshop": {
-      "url": "http://127.0.0.1:9765/mcp/dcc/photoshop"
+      "url": "http://127.0.0.1:9765/mcp"
     }
   }
 }
@@ -100,7 +100,7 @@ The bundled sidecar starts automatically and listens on the following ports. MCP
 ```
 Name: photoshop
 Type: url
-URL: http://127.0.0.1:9765/mcp/dcc/photoshop
+URL: http://127.0.0.1:9765/mcp
 ```
 
 **VS Code / 通用 MCP 客户端 / Generic MCP client**:
@@ -110,15 +110,15 @@ URL: http://127.0.0.1:9765/mcp/dcc/photoshop
   "mcp": {
     "servers": {
       "photoshop": {
-        "url": "http://127.0.0.1:9765/mcp/dcc/photoshop"
+        "url": "http://127.0.0.1:9765/mcp"
       }
     }
   }
 }
 ```
 
-> 网关地址格式为 `http://127.0.0.1:9765/mcp/dcc/photoshop`，其中 `9765` 是网关端口，`photoshop` 是 DCC 类型。网关会自动发现并路由到正确的服务实例。
-> The gateway URL format is `http://127.0.0.1:9765/mcp/dcc/photoshop` where `9765` is the gateway port and `photoshop` is the DCC type. The gateway auto-discovers and routes to the correct service instance.
+> 网关 `/mcp` 端点是一个统一 facade，聚合所有已注册 DCC（Maya / Houdini / Blender / Photoshop 等）的工具列表。`tools/call` 时网关通过 capability index 自动发现并路由到正确的 DCC 实例，无需在 URL 中指定 DCC 类型。
+> The gateway `/mcp` endpoint is a unified facade that aggregates tools from ALL registered DCCs (Maya / Houdini / Blender / Photoshop, etc.). On `tools/call`, the gateway auto-discovers the correct DCC instance via the capability index — no need to specify the DCC type in the URL.
 
 ### 4. 启动使用 / Start using
 
@@ -412,7 +412,7 @@ dcc-mcp-photoshop v0.1.6
   WS bridge   : ws://localhost:9001
   RPC endpoint: http://localhost:9100/rpc
 
-MCP clients: http://127.0.0.1:8765/mcp (direct) or http://127.0.0.1:9765/mcp/dcc/photoshop (gateway)
+MCP clients: http://127.0.0.1:8765/mcp (direct) or http://127.0.0.1:9765/mcp (gateway)
 
 Waiting for Photoshop UXP plugin to connect...
 Press Ctrl+C to stop.
@@ -436,7 +436,7 @@ python -m dcc_mcp_photoshop
 
 **MCP clients** connect to:
 - `http://127.0.0.1:8765/mcp` — Direct, stable port
-- `http://127.0.0.1:9765/mcp/dcc/photoshop` — Gateway proxy (auto-detects DCC type)
+- `http://127.0.0.1:9765/mcp` — Gateway proxy (unified facade for all DCCs)
 
 ### Python API
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,106 @@ Adobe Photoshop 2022+
 - The MCP server (HTTP on port 8765) and the WebSocket bridge can run in the same process (embedded, dev only) or separately (gateway mode, recommended for deployment).
 - All Photoshop automation goes through the [adobepy](https://github.com/dcc-mcp/adobepy) facade layer, which abstracts over the WebSocket bridge.
 
+## 快速开始 / Quick Start
+
+> 下载安装 UXP 插件，配置统一网关地址，即可让 AI 助手控制 Photoshop。
+> Download and install the UXP plugin, configure the gateway URL, and your AI assistant can control Photoshop.
+
+### 1. 下载插件 / Download the plugin
+
+从 [GitHub Releases](https://github.com/dcc-mcp/dcc-mcp-photoshop/releases) 下载最新的 `.ccx` 文件：
+Download the latest `.ccx` file from [GitHub Releases](https://github.com/dcc-mcp/dcc-mcp-photoshop/releases):
+
+![Release assets](https://img.shields.io/github/v/release/dcc-mcp/dcc-mcp-photoshop)
+
+| 文件 / File | 说明 / Description |
+|-------------|-------------------|
+| `dcc-mcp-photoshop-bridge-<version>.ccx` | UXP 插件，内含 sidecar 服务（dcc-mcp-server + bridge） / UXP plugin with bundled sidecar |
+
+### 2. 安装插件 / Install the plugin
+
+**方式 A — Creative Cloud Desktop（推荐 / Recommended）:**
+
+1. 打开 **Creative Cloud Desktop** → **Plugins** → **Manage Plugins**
+2. 点击齿轮图标 → **Install from file...**
+3. 选择下载的 `.ccx` 文件
+4. 重启 Photoshop
+
+**方式 B — 手动安装 / Manual install:**
+
+Windows:
+```powershell
+copy dcc-mcp-photoshop-bridge-*.ccx "$env:APPDATA\Adobe\UXP\Plugins\External\"
+```
+
+macOS:
+```bash
+cp dcc-mcp-photoshop-bridge-*.ccx ~/Library/Application\ Support/Adobe/UXP/Plugins/External/
+```
+
+安装后重启 Photoshop，插件会自动出现在 **Plugins** 面板中，名称为 "dcc-mcp Bridge"。
+After restarting Photoshop, the plugin appears in the **Plugins** panel as "dcc-mcp Bridge".
+
+### 3. 配置网关地址 / Configure the gateway
+
+插件内置的 sidecar 服务启动后会监听以下端口。MCP 客户端只需配置统一的网关地址即可：
+The bundled sidecar starts automatically and listens on the following ports. MCP clients only need the gateway URL:
+
+| 端口 / Port | 用途 / Purpose |
+|------------|----------------|
+| `8765` | MCP HTTP 服务器（直连） / MCP HTTP server (direct) |
+| `9001` | WebSocket bridge（PS ↔ Python） |
+| `9100` | HTTP RPC 服务器（跨进程 bridge） |
+| `9765` | 网关代理 / Gateway proxy |
+
+**Claude Desktop 配置 / Claude Desktop config** (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "photoshop": {
+      "url": "http://127.0.0.1:9765/mcp/dcc/photoshop"
+    }
+  }
+}
+```
+
+**Cursor 配置 / Cursor config** (Settings → Features → MCP Servers):
+
+```
+Name: photoshop
+Type: url
+URL: http://127.0.0.1:9765/mcp/dcc/photoshop
+```
+
+**VS Code / 通用 MCP 客户端 / Generic MCP client**:
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "photoshop": {
+        "url": "http://127.0.0.1:9765/mcp/dcc/photoshop"
+      }
+    }
+  }
+}
+```
+
+> 网关地址格式为 `http://127.0.0.1:9765/mcp/dcc/photoshop`，其中 `9765` 是网关端口，`photoshop` 是 DCC 类型。网关会自动发现并路由到正确的服务实例。
+> The gateway URL format is `http://127.0.0.1:9765/mcp/dcc/photoshop` where `9765` is the gateway port and `photoshop` is the DCC type. The gateway auto-discovers and routes to the correct service instance.
+
+### 4. 启动使用 / Start using
+
+1. 确保 Photoshop 已打开并加载了 UXP 插件
+2. 插件会自动启动 sidecar 服务（`dcc-mcp-server.exe` + bridge）
+3. 在 MCP 客户端中配置上述网关地址
+4. 开始让 AI 控制 Photoshop
+
+Make sure Photoshop is running with the UXP plugin loaded. The sidecar auto-starts. Configure the gateway URL in your MCP client and start controlling Photoshop with AI.
+
+---
+
 ## Features
 
 **Current (v0.1.x):**

--- a/README.md
+++ b/README.md
@@ -129,6 +129,26 @@ URL: http://127.0.0.1:9765/mcp
 
 Make sure Photoshop is running with the UXP plugin loaded. The sidecar auto-starts. Configure the gateway URL in your MCP client and start controlling Photoshop with AI.
 
+### 5. 一键安装配置 / One-Click Setup
+
+如果通过 AI 助手使用，加载 `photoshop-setup` skill 即可自动化全流程：
+When using through an AI assistant, load the `photoshop-setup` skill for one-click automation:
+
+```
+load_skill("photoshop-setup")
+```
+
+| 工具 / Tool | 说明 / Description |
+|-------------|-------------------|
+| `check_environment` | 检查系统环境 / Check system prerequisites |
+| `install_package` | 安装 pip 包 / Install via pip |
+| `setup_uxp_plugin` | 安装 UXP 插件 / Install UXP .ccx plugin |
+| `start_server` | 启动服务器（开发模式）/ Start server (dev mode) |
+| `verify_connection` | 验证连接 / Verify bridge connection |
+| `configure_mcp_client` | 自动配置 Claude Desktop / Cursor / VS Code / Auto-configure MCP client |
+
+工作流 / Workflow: `check_environment` → `setup_uxp_plugin` → `configure_mcp_client` → 完成 / done。
+
 ---
 
 ## Features

--- a/src/dcc_mcp_photoshop/api.py
+++ b/src/dcc_mcp_photoshop/api.py
@@ -32,7 +32,9 @@ Legacy compat (deprecated — still works)::
 from __future__ import annotations
 
 import functools
+import json
 import logging
+import os
 from typing import Any, Callable, Dict, List, Optional, TypeVar
 
 logger = logging.getLogger(__name__)
@@ -47,6 +49,38 @@ _bridge = None
 # so that child processes (e.g. skill scripts running under dcc-mcp-server)
 # can discover the bridge via os.environ or dcc_mcp_photoshop.api.get_bridge().
 BRIDGE_URL_ENV_VAR = "DCC_MCP_PHOTOSHOP_BRIDGE_URL"
+
+_BRIDGE_CONFIG_PATH = os.path.expanduser("~/.dcc-mcp/bridge-photoshop.json")
+
+
+def _write_bridge_url_to_config(rpc_url: str) -> None:
+    """Write the RPC endpoint URL to the bridge config file.
+
+    Skill scripts running inside ``dcc-mcp-server.exe`` read this file
+    to discover the bridge's RPC endpoint for cross-process access.
+    """
+    config = {}
+    if os.path.isfile(_BRIDGE_CONFIG_PATH):
+        try:
+            with open(_BRIDGE_CONFIG_PATH) as f:
+                config = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            pass
+    config["dcc_type"] = "photoshop"
+    config["bridge_url"] = rpc_url
+    os.makedirs(os.path.dirname(_BRIDGE_CONFIG_PATH), exist_ok=True)
+    with open(_BRIDGE_CONFIG_PATH, "w") as f:
+        json.dump(config, f, indent=2, ensure_ascii=False)
+
+
+def _remove_bridge_config() -> None:
+    """Remove the bridge config file."""
+    try:
+        os.remove(_BRIDGE_CONFIG_PATH)
+    except FileNotFoundError:
+        pass
+    except OSError:
+        logger.debug("Failed to remove bridge config: %s", _BRIDGE_CONFIG_PATH)
 
 
 # ---------------------------------------------------------------------------

--- a/src/dcc_mcp_photoshop/skills/photoshop-setup/SKILL.md
+++ b/src/dcc_mcp_photoshop/skills/photoshop-setup/SKILL.md
@@ -39,6 +39,12 @@ tools:
     read_only: true
     destructive: false
     idempotent: true
+  - name: configure_mcp_client
+    description: "Configure MCP client (Claude Desktop, Cursor, VS Code) with the gateway URL — auto-writes config or prints manual steps."
+    source_file: scripts/configure_mcp_client.py
+    read_only: false
+    destructive: false
+    idempotent: true
 ---
 
 # photoshop-setup
@@ -57,15 +63,17 @@ installation, configuration, and verification flow.
 ## Workflow
 
 1. **check_environment** — Inspect the current system state
-2. **install_package** — Install dcc-mcp-photoshop via pip (or skip if using binary)
+2. **install_package** — Install dcc-mcp-photoshop via pip (or skip if using .ccx sidecar)
 3. **setup_uxp_plugin** — Install the UXP .ccx plugin in Photoshop
-4. **start_server** — Launch the MCP server (embedded mode)
+4. **start_server** — Launch the MCP server (embedded mode for dev)
 5. **verify_connection** — Confirm everything is working
+6. **configure_mcp_client** — Auto-configure Claude Desktop / Cursor / VS Code with the gateway URL
 
 ## Tools
 
 - `check_environment` — Python / pip / installed packages / Photoshop process / UXP port
 - `install_package` — pip install dcc-mcp-photoshop
 - `setup_uxp_plugin` — Download and install the .ccx plugin
-- `start_server` — Start embedded MCP server + bridge
+- `start_server` — Start embedded MCP server + bridge (dev mode)
 - `verify_connection` — End-to-end connection check
+- `configure_mcp_client` — Write MCP client config for Claude Desktop / Cursor / VS Code

--- a/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/configure_mcp_client.py
+++ b/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/configure_mcp_client.py
@@ -1,0 +1,273 @@
+"""Configure MCP client to connect to the dcc-mcp gateway."""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry
+
+
+def _find_claude_config_paths() -> list[str]:
+    """Return possible Claude Desktop config paths for the current platform."""
+    system = platform.system()
+    if system == "Windows":
+        appdata = os.environ.get("APPDATA", "")
+        return [os.path.join(appdata, "Claude", "claude_desktop_config.json")]
+    elif system == "Darwin":
+        home = os.path.expanduser("~")
+        return [os.path.join(home, "Library", "Application Support", "Claude", "claude_desktop_config.json")]
+    else:
+        home = os.path.expanduser("~")
+        return [os.path.join(home, ".config", "Claude", "claude_desktop_config.json")]
+
+
+def _find_vscode_config_paths() -> list[str]:
+    """Return possible VS Code settings paths."""
+    system = platform.system()
+    if system == "Windows":
+        appdata = os.environ.get("APPDATA", "")
+        pfx = os.path.join(appdata, "Code")
+    elif system == "Darwin":
+        home = os.path.expanduser("~")
+        pfx = os.path.join(home, "Library", "Application Support", "Code")
+    else:
+        home = os.path.expanduser("~")
+        pfx = os.path.join(home, ".config", "Code")
+
+    settings_files = []
+    for variant in ["User", "User/globalStorage"]:
+        p = os.path.join(pfx, variant, "settings.json")
+        settings_files.append(p)
+    return settings_files
+
+
+def _configure_claude(gateway_url: str, server_name: str, overwrite: bool) -> dict:
+    """Write or update claude_desktop_config.json."""
+    config_paths = _find_claude_config_paths()
+    config_path = None
+    for p in config_paths:
+        if os.path.isfile(p) or os.path.isdir(os.path.dirname(p)):
+            config_path = p
+            break
+
+    if not config_path:
+        return {
+            "ok": False,
+            "path": config_paths[0] if config_paths else "",
+            "detail": "Claude Desktop config directory not found. Is Claude Desktop installed?",
+            "guide": _claude_manual_guide(gateway_url, server_name),
+        }
+
+    config = {}
+    if os.path.isfile(config_path) and not overwrite:
+        try:
+            with open(config_path) as f:
+                config = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    if "mcpServers" not in config:
+        config["mcpServers"] = {}
+
+    config["mcpServers"][server_name] = {
+        "url": gateway_url,
+    }
+
+    os.makedirs(os.path.dirname(config_path), exist_ok=True)
+    with open(config_path, "w") as f:
+        json.dump(config, f, indent=2)
+        f.write("\n")
+
+    return {
+        "ok": True,
+        "path": config_path,
+        "detail": f"Claude Desktop configured: {server_name} → {gateway_url}",
+    }
+
+
+def _configure_cursor(gateway_url: str, server_name: str) -> dict:
+    """Generate Cursor MCP setup guide (Cursor needs manual UI input)."""
+    guide = (
+        f"# Cursor MCP Configuration\n"
+        f"\n"
+        f"1. Open Cursor → Settings (Ctrl+Comma / Cmd+Comma)\n"
+        f"2. Go to Features → MCP Servers\n"
+        f"3. Click 'Add New MCP Server'\n"
+        f"\n"
+        f"   Name: {server_name}\n"
+        f"   Type: HTTP (SSE / Streamable HTTP)\n"
+        f"   URL: {gateway_url}\n"
+        f"\n"
+        f"4. Click Save\n"
+        f"5. Test by asking the AI to list tools\n"
+    )
+    return {
+        "ok": False,
+        "detail": "Cursor configuration must be done manually in the UI",
+        "guide": guide,
+    }
+
+
+def _configure_vscode(gateway_url: str, server_name: str, overwrite: bool) -> dict:
+    """Write or update VS Code MCP settings."""
+    config_paths = _find_vscode_config_paths()
+    config_path = None
+    for p in config_paths:
+        if os.path.isfile(p) or (os.path.dirname(p) and any(
+            os.path.isdir(os.path.dirname(p).replace("globalStorage", x))
+            for x in ["globalStorage", "User"]
+        )):
+            config_path = p
+            break
+
+    if not config_path:
+        return {
+            "ok": False,
+            "path": config_paths[0] if config_paths else "",
+            "detail": "VS Code settings not found",
+            "guide": _vscode_manual_guide(gateway_url, server_name),
+        }
+
+    config = {}
+    if os.path.isfile(config_path) and not overwrite:
+        try:
+            with open(config_path) as f:
+                config = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    if "mcp" not in config:
+        config["mcp"] = {}
+    if "servers" not in config["mcp"]:
+        config["mcp"]["servers"] = {}
+
+    config["mcp"]["servers"][server_name] = {
+        "url": gateway_url,
+    }
+
+    os.makedirs(os.path.dirname(config_path), exist_ok=True)
+    with open(config_path, "w") as f:
+        json.dump(config, f, indent=4)
+        f.write("\n")
+
+    return {
+        "ok": True,
+        "path": config_path,
+        "detail": f"VS Code configured: {server_name} → {gateway_url}",
+    }
+
+
+def _claude_manual_guide(gateway_url: str, server_name: str) -> str:
+    """Generate manual Claude Desktop config instructions."""
+    config = {
+        "mcpServers": {
+            server_name: {
+                "url": gateway_url,
+            }
+        }
+    }
+    config_json = json.dumps(config, indent=2)
+
+    paths = _find_claude_config_paths()
+    return (
+        f"# Claude Desktop Manual Configuration\n"
+        f"\n"
+        f"Create or edit: {paths[0] if paths else 'claude_desktop_config.json'}\n"
+        f"\n"
+        f"```json\n{config_json}\n```\n"
+    )
+
+
+def _vscode_manual_guide(gateway_url: str, server_name: str) -> str:
+    """Generate manual VS Code config instructions."""
+    config = {
+        "mcp": {
+            "servers": {
+                server_name: {
+                    "url": gateway_url,
+                }
+            }
+        }
+    }
+    config_json = json.dumps(config, indent=4)
+
+    return (
+        f"# VS Code Manual Configuration\n"
+        f"\n"
+        f"Add to your VS Code `settings.json`:\n"
+        f"\n"
+        f"```json\n{config_json}\n```\n"
+    )
+
+
+@skill_entry
+def configure_mcp_client(
+    client_type: str = "claude_desktop",
+    server_name: str = "photoshop",
+    gateway_url: str = "http://127.0.0.1:9765/mcp",
+    overwrite: bool = False,
+    **kwargs,
+) -> dict:
+    """Configure an MCP client to connect to the dcc-mcp gateway.
+
+    Writes or generates configuration for Claude Desktop, Cursor, or VS Code
+    so the AI assistant can talk to Photoshop through the dcc-mcp gateway.
+
+    Args:
+        client_type: Target client: "claude_desktop", "cursor", "vscode", or "all".
+        server_name: Server name shown in the MCP client (default: "photoshop").
+        gateway_url: Gateway MCP endpoint URL (default: http://127.0.0.1:9765/mcp).
+        overwrite: Replace existing config instead of merging.
+
+    Returns:
+        dict: Configuration result per client.
+    """
+    valid_types = {"claude_desktop", "cursor", "vscode", "all"}
+    if client_type not in valid_types:
+        return {
+            "success": False,
+            "summary": f"Invalid client_type: {client_type}",
+            "details": {},
+            "prompt": f"Choose one of: {', '.join(sorted(valid_types))}",
+        }
+
+    results = {}
+
+    if client_type in ("claude_desktop", "all"):
+        results["claude_desktop"] = _configure_claude(gateway_url, server_name, overwrite)
+
+    if client_type in ("cursor", "all"):
+        results["cursor"] = _configure_cursor(gateway_url, server_name)
+
+    if client_type in ("vscode", "all"):
+        results["vscode"] = _configure_vscode(gateway_url, server_name, overwrite)
+
+    configured = [k for k, v in results.items() if v.get("ok")]
+    if configured:
+        summary = f"MCP client(s) configured: {', '.join(configured)} → {gateway_url}"
+    else:
+        summary = "Configuration generated (manual steps required for some clients)"
+
+    return {
+        "success": len(configured) > 0 or client_type == "cursor",
+        "summary": summary,
+        "details": results,
+        "prompt": (
+            "Restart your MCP client (Claude Desktop / Cursor / VS Code) to pick up the new config. "
+            "Use verify_connection to confirm the bridge is working, then use tools like "
+            "photoshop-document/list_layers or photoshop-image/create_document."
+        ),
+    }
+
+
+def main(**kwargs) -> dict:
+    return configure_mcp_client(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/configure_mcp_client.py
+++ b/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/configure_mcp_client.py
@@ -115,10 +115,10 @@ def _configure_vscode(gateway_url: str, server_name: str, overwrite: bool) -> di
     config_paths = _find_vscode_config_paths()
     config_path = None
     for p in config_paths:
-        if os.path.isfile(p) or (os.path.dirname(p) and any(
-            os.path.isdir(os.path.dirname(p).replace("globalStorage", x))
-            for x in ["globalStorage", "User"]
-        )):
+        if os.path.isfile(p) or (
+            os.path.dirname(p)
+            and any(os.path.isdir(os.path.dirname(p).replace("globalStorage", x)) for x in ["globalStorage", "User"])
+        ):
             config_path = p
             break
 
@@ -193,13 +193,7 @@ def _vscode_manual_guide(gateway_url: str, server_name: str) -> str:
     }
     config_json = json.dumps(config, indent=4)
 
-    return (
-        f"# VS Code Manual Configuration\n"
-        f"\n"
-        f"Add to your VS Code `settings.json`:\n"
-        f"\n"
-        f"```json\n{config_json}\n```\n"
-    )
+    return f"# VS Code Manual Configuration\n\nAdd to your VS Code `settings.json`:\n\n```json\n{config_json}\n```\n"
 
 
 @skill_entry

--- a/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/configure_mcp_client.py
+++ b/src/dcc_mcp_photoshop/skills/photoshop-setup/scripts/configure_mcp_client.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import os
 import platform
-from pathlib import Path
 
 from dcc_mcp_core.skill import skill_entry
 

--- a/src/dcc_mcp_photoshop/skills/photoshop-setup/tools.yaml
+++ b/src/dcc_mcp_photoshop/skills/photoshop-setup/tools.yaml
@@ -122,3 +122,35 @@ tools:
     read_only: true
     destructive: false
     idempotent: true
+
+  - name: configure_mcp_client
+    description: "Configure MCP client (Claude Desktop, Cursor, VS Code) with the gateway URL — auto-writes config or prints manual steps."
+    source_file: scripts/configure_mcp_client.py
+    inputSchema:
+      type: object
+      properties:
+        client_type:
+          type: string
+          enum: [claude_desktop, cursor, vscode, all]
+          default: claude_desktop
+          description: |
+            Target MCP client to configure:
+            - claude_desktop: Write/update claude_desktop_config.json
+            - cursor: Print manual setup guide (Cursor requires UI input)
+            - vscode: Write/update VS Code settings.json
+            - all: Configure all detected clients
+        server_name:
+          type: string
+          default: photoshop
+          description: Server name shown in the MCP client configuration.
+        gateway_url:
+          type: string
+          default: "http://127.0.0.1:9765/mcp"
+          description: Gateway MCP endpoint URL.
+        overwrite:
+          type: boolean
+          default: false
+          description: Replace existing config instead of merging with it.
+    read_only: false
+    destructive: false
+    idempotent: true

--- a/vx.toml
+++ b/vx.toml
@@ -1,0 +1,27 @@
+[tools]
+python = "3.12"
+uv = "latest"
+
+[settings]
+cache_duration = "7d"
+auto_install = true
+
+[scripts]
+# === Development ===
+dev = "uv pip install -e \".[dev]\""
+install = "uv pip install -e \".[dev]\""
+
+# === Lint & Format ===
+lint = "uv run ruff check src/ tests/"
+lint-fix = "uv run ruff check --fix src/ tests/"
+format = "uv run ruff format src/ tests/"
+format-check = "uv run ruff format --check src/ tests/"
+preflight = "uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/"
+
+# === Test ===
+test = "uv run pytest tests/ -v --tb=short"
+test-cov = "uv run pytest tests/ -v --tb=short --cov=src/dcc_mcp_photoshop"
+
+# === Pre-commit (vx prek) ===
+prek = "pre-commit run --all-files"
+prek-install = "pre-commit install"


### PR DESCRIPTION
## Summary

Fix `ImportError: cannot import name '_write_bridge_url_to_config'` in v0.1.4+ bridge-only mode.

- `PhotoshopBridgePlugin.connect()` and `disconnect()` import `_write_bridge_url_to_config` / `_remove_bridge_config` from `dcc_mcp_photoshop.api`, but these functions were never defined
- Added both functions to manage `~/.dcc-mcp/bridge-photoshop.json` for cross-process bridge URL discovery

## Sidecar Confirmation

The sidecar service pattern is already fully implemented:
- `bridge/uxp-plugin/sidecar/` contains `dcc-mcp-server.exe` + skills + start/stop scripts
- `tools/pack_plugin.py` generates launcher/stopper scripts
- `tools/stage_plugin_sidecar.py` stages sidecar into UXP plugin tree during CI
- Bridge process stays alive independently even without gateway