### PR TITLE
feat: switch packaging from PyInstaller to PyOxidizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ pip install -e ".[dev]"
 
 ### Standalone Binary
 
-Each [GitHub Release](https://github.com/dcc-mcp/dcc-mcp-photoshop/releases) includes platform-specific binaries built with PyInstaller. No Python runtime required.
+Each [GitHub Release](https://github.com/dcc-mcp/dcc-mcp-photoshop/releases) includes platform-specific binaries built with PyOxidizer. No Python runtime required.
 
 | Platform | Binary name |
 |----------|-------------|
@@ -581,6 +581,7 @@ pytest tests/
   - `dcc-mcp-core >= 0.18.14, < 1.0.0`
   - `adobepy >= 0.1.0`
   - `websockets >= 12.0`
+- **Build** (to build standalone binary from source): Python 3.8+, [Rust toolchain](https://rustup.rs/), and PyOxidizer (`pip install pyoxidizer`)
 
 | Path | Photoshop Required? | Python Required? |
 |------|-------------------|-----------------|

--- a/pyoxidizer.bzl
+++ b/pyoxidizer.bzl
@@ -1,0 +1,60 @@
+# This file defines how PyOxidizer application building and packaging is
+# performed. See PyOxidizer's documentation at
+# https://pyoxidizer.readthedocs.io/en/stable/ for details of this
+# configuration file format.
+#
+# Output: a standalone dcc-mcp-photoshop binary — single file,
+# zero Python deps for end user.
+
+def make_exe():
+    # Obtain the default Python distribution for our build target.
+    dist = default_python_distribution()
+
+    # Configure packaging policy.
+    policy = dist.make_python_packaging_policy()
+
+    # Fall back to loading resources from a "lib" directory next to the binary
+    # when in-memory loading fails.
+    policy.resources_location_fallback = "filesystem-relative:lib"
+
+    # Configure the embedded Python interpreter.
+    python_config = dist.make_python_interpreter_config()
+
+    # Set module search path so the interpreter can find installed packages.
+    python_config.module_search_paths = ["$ORIGIN/lib"]
+
+    # Run dcc_mcp_photoshop.cli as __main__ when the binary starts.
+    python_config.run_module = "dcc_mcp_photoshop.cli"
+
+    # Forward command-line arguments to the Python program.
+    python_config.parse_argv = True
+
+    # Produce a PythonExecutable from the distribution, embedded resources,
+    # and the configuration above.
+    exe = dist.to_python_executable(
+        name="dcc-mcp-photoshop",
+        packaging_policy=policy,
+        config=python_config,
+    )
+
+    # Install our package and all its dependencies via pip.
+    # Hatchling includes all package data (YAML, MD, etc.) from the
+    # src/dcc_mcp_photoshop/ tree, so built-in skills are bundled.
+    exe.add_python_resources(exe.pip_install(["."]))
+
+    return exe
+
+
+def make_install(exe):
+    # Create an object representing our installed application file layout.
+    files = FileManifest()
+
+    # Add the generated executable to the install layout root.
+    files.add_python_resource(".", exe)
+
+    return files
+
+
+register_target("exe", make_exe)
+register_target("install", make_install, depends=["exe"], default=True)
+resolve_targets()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dev = [
     "hatchling",
     "build",
     "pyyaml>=6.0",
-    "pyinstaller>=6.0",
+    "pyoxidizer>=0.24.0",
 ]
 
 [project.urls]

--- a/tools/build_binary.py
+++ b/tools/build_binary.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
-"""Build the dcc-mcp-photoshop standalone binary using PyInstaller.
+"""Build the dcc-mcp-photoshop standalone binary using PyOxidizer.
 
 Output: dist/dcc-mcp-photoshop[.exe]  — single file, zero Python deps for end user.
 
-Usage:
+Usage::
+
     python tools/build_binary.py
-    python tools/build_binary.py --onedir   # directory mode (faster startup)
-    python tools/build_binary.py --debug    # keep temp files for inspection
+    python tools/build_binary.py --debug    # verbose build output for inspection
+
+Prerequisites:
+  - Python 3.8+
+  - Rust toolchain (install from https://rustup.rs/)
+  - PyOxidizer (``pip install pyoxidizer``)
 
 The resulting binary can be:
   - Distributed with the Photoshop UXP plugin (.ccx)
@@ -17,106 +22,132 @@ The resulting binary can be:
 from __future__ import annotations
 
 import argparse
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).parent.parent
-SRC_ROOT = PROJECT_ROOT / "src"
 DIST_DIR = PROJECT_ROOT / "dist"
+BUILD_DIR = PROJECT_ROOT / "build"
 BINARY_NAME = "dcc-mcp-photoshop"
 
 
+def _check_pyoxidizer() -> None:
+    """Verify PyOxidizer is installed and accessible."""
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "pyoxidizer", "--version"],
+            capture_output=True, check=True, text=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        print("ERROR: PyOxidizer not found. Run: pip install pyoxidizer")
+        sys.exit(1)
+
+
+def _check_rust() -> None:
+    """Verify the Rust toolchain is available (required by PyOxidizer)."""
+    try:
+        subprocess.run(["cargo", "--version"], capture_output=True, check=True, text=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        print(
+            "ERROR: Rust toolchain not found. "
+            "Install from https://rustup.rs/ or run: rustup-init.exe",
+        )
+        sys.exit(1)
+
+
+def _find_binary(build_dir: Path) -> Path | None:
+    """Locate the built binary under *build_dir*.
+
+    PyOxidizer places output in a platform/target-specific path like::
+
+        build/<target-triple>/release/install/dcc-mcp-photoshop[.exe]
+
+    This function searches the build tree for the binary by name.
+    """
+    matches = sorted(build_dir.rglob(BINARY_NAME + (".exe" if sys.platform == "win32" else "")))
+    if matches:
+        return matches[-1]  # Return the last match (deepest/most specific)
+    return None
+
+
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Build dcc-mcp-photoshop standalone binary")
-    parser.add_argument("--onedir", action="store_true",
-                        help="Build as directory (faster startup) instead of single file")
-    parser.add_argument("--debug", action="store_true",
-                        help="Keep temp files for inspection")
-    parser.add_argument("--upx", action="store_true",
-                        help="Compress binary with UPX (requires UPX installed)")
+    parser = argparse.ArgumentParser(
+        description="Build the dcc-mcp-photoshop standalone binary using PyOxidizer",
+        epilog=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--debug", action="store_true",
+        help="Enable verbose build output for inspection",
+    )
     args = parser.parse_args()
 
-    # Ensure PyInstaller is available
-    try:
-        import PyInstaller  # noqa: F401
-    except ImportError:
-        print("ERROR: PyInstaller not found. Run: pip install pyinstaller")
+    # Check prerequisites
+    _check_pyoxidizer()
+    _check_rust()
+
+    config = PROJECT_ROOT / "pyoxidizer.bzl"
+    if not config.exists():
+        print(f"ERROR: PyOxidizer config not found: {config}")
         sys.exit(1)
 
-    entry_point = SRC_ROOT / "dcc_mcp_photoshop" / "cli.py"
-    if not entry_point.exists():
-        print(f"ERROR: Entry point not found: {entry_point}")
-        sys.exit(1)
-
-    cmd = [
-        sys.executable, "-m", "PyInstaller",
-        "--name", BINARY_NAME,
-        "--distpath", str(DIST_DIR / "binary"),
-        "--workpath", str(PROJECT_ROOT / "build" / "pyinstaller"),
-        "--specpath", str(PROJECT_ROOT / "build"),
-        "--paths", str(SRC_ROOT),
-        # Include the built-in skills directory
-        "--add-data", f"{SRC_ROOT / 'dcc_mcp_photoshop' / 'skills'}{_sep()}dcc_mcp_photoshop/skills",
-        "--hidden-import", "dcc_mcp_photoshop",
-        "--hidden-import", "dcc_mcp_photoshop.server",
-        "--hidden-import", "dcc_mcp_photoshop.bridge",
-        "--hidden-import", "dcc_mcp_photoshop.api",
-        "--hidden-import", "dcc_mcp_photoshop.capabilities",
-        "--hidden-import", "dcc_mcp_core",
-        "--hidden-import", "websockets",
-        "--hidden-import", "websockets.asyncio",
-        "--hidden-import", "websockets.asyncio.server",
-        "--collect-all", "dcc_mcp_core",
-        "--collect-all", "websockets",
-    ]
-
-    if args.onedir:
-        cmd.append("--onedir")
-    else:
-        cmd.append("--onefile")
-
-    if not args.debug:
-        cmd.append("--clean")
-
-    if not args.upx:
-        cmd.append("--noupx")
-
-    # Add console (keep terminal open to see logs)
-    cmd.append("--console")
-
-    cmd.append(str(entry_point))
+    output_dir = DIST_DIR / "binary"
+    output_dir.mkdir(parents=True, exist_ok=True)
 
     print(f"Building: {BINARY_NAME}")
-    print(f"Mode: {'directory' if args.onedir else 'single file'}")
-    print(f"Output: {DIST_DIR / 'binary'}")
+    print(f"Config:   {config}")
+    print(f"Output:   {output_dir}")
     print()
+
+    cmd = [
+        sys.executable, "-m", "pyoxidizer", "build",
+        "--path", str(PROJECT_ROOT),
+    ]
+
+    if args.debug:
+        cmd.append("--verbose")
+        print(f"Command: {' '.join(cmd)}")
+        print()
 
     result = subprocess.run(cmd, check=False)
     if result.returncode != 0:
         print(f"\nBuild FAILED (exit code {result.returncode})")
         sys.exit(result.returncode)
 
-    binary = DIST_DIR / "binary" / BINARY_NAME
-    if sys.platform == "win32":
-        binary = binary.with_suffix(".exe")
-        if not binary.exists():
-            binary = DIST_DIR / "binary" / BINARY_NAME / f"{BINARY_NAME}.exe"
+    # Locate the built binary
+    pyoxidizer_build_dir = BUILD_DIR / "pyoxidizer"
+    binary = _find_binary(pyoxidizer_build_dir) if pyoxidizer_build_dir.exists() else None
 
+    if binary is None:
+        for candidate in BUILD_DIR.iterdir():
+            if candidate.is_dir() and candidate.name != "pyoxidizer":
+                found = _find_binary(candidate)
+                if found:
+                    binary = found
+                    break
+
+    if binary is None or not binary.exists():
+        print(
+            f"\nERROR: Built binary not found in {BUILD_DIR}. "
+            "Check build output above.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Copy binary to dist/binary/
+    dest = output_dir / binary.name
+    shutil.copy2(binary, dest)
+
+    size_mb = dest.stat().st_size / 1_048_576
     print(f"\nBuild complete!")
-    if binary.exists():
-        size_mb = binary.stat().st_size / 1_048_576
-        print(f"  Binary: {binary}  ({size_mb:.1f} MB)")
+    print(f"  Binary: {dest}  ({size_mb:.1f} MB)")
     print()
     print("Usage:")
-    print(f"  {binary.name} --help")
-    print(f"  {binary.name}                  # default ports (MCP:8765, WS:9001)")
-    print(f"  {binary.name} --mcp-port 9000  # custom ports")
-
-
-def _sep() -> str:
-    """PyInstaller --add-data separator: ';' on Windows, ':' on Unix."""
-    return ";" if sys.platform == "win32" else ":"
+    print(f"  {dest.name} --help")
+    print(f"  {dest.name}                  # default ports (MCP:8765, WS:9001)")
+    print(f"  {dest.name} --mcp-port 9000  # custom ports")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Switch `tools/build_binary.py` from PyInstaller to PyOxidizer for smaller
binary size and better cross-platform support, following the approach used
in [photoshop-python-interpreter](https://github.com/loonghao/photoshop-python-interpreter).

### Changes

- **pyoxidizer.bzl** (new) — PyOxidizer Starlark configuration defining:
  - Python distribution embedding strategy
  - Entry point: `dcc_mcp_photoshop.cli`
  - Pip-based dependency bundling via `pip_install(["."])`
- **tools/build_binary.py** — Rewritten for PyOxidizer:
  - Drop PyInstaller-specific flags (`--onedir`, `--upx`)
  - Add Rust toolchain prerequisite check
  - Locate binary under `build/` after build completes
  - Output path unchanged: `dist/binary/dcc-mcp-photoshop[.exe]`
- **pyproject.toml** — dev dependency: `pyinstaller>=6.0` -> `pyoxidizer>=0.24.0`
- **README.md** — Update "built with PyInstaller" -> "built with PyOxidizer",
  add build requirements (Rust + PyOxidizer) to Requirements section

### Prerequisites (build only)

Building the standalone binary now requires:
- Python 3.8+
- Rust toolchain (https://rustup.rs/)
- `pip install pyoxidizer`

The GitHub CI (`release.yml`) already has the `dtolnay/rust-toolchain@stable` step
from recent main commits, so CI builds work without additional changes.

### Backward compatibility

- Output binary name and location unchanged: `dist/binary/dcc-mcp-photoshop[.exe]`
- CLI flags unchanged
- UXP plugin sidecar staging unchanged
- pip install workflow unchanged

## Test plan

- [ ] `python tools/build_binary.py` succeeds (requires Rust + PyOxidizer)
- [ ] `git diff origin/main` confirms only intended files changed
- [ ] CI pipeline builds binary on all three platforms
