### PR TITLE
docs: add AGENTS.md/CLAUDE.md/llms.txt, fix distribution.md/PRD.md/uxp-readme

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,97 @@
+# AGENTS.md — dcc-mcp-photoshop
+
+> **Navigation map, not a reference manual.**
+> Follow the links; don't read everything upfront.
+> Agent-specific files (`CLAUDE.md`, `GEMINI.md`, `COPILOT.md`) intentionally point back here.
+
+## Project Overview
+
+**dcc-mcp-photoshop** turns Adobe Photoshop into an MCP Streamable HTTP backend via a UXP WebSocket plugin. The Python bridge runs a WebSocket server on port 9001; the UXP plugin inside Photoshop connects as a client.
+
+## Agent Entry Path
+
+```
+AI Agent
+  │  MCP Streamable HTTP → http://127.0.0.1:9765/mcp
+  ▼
+dcc-mcp-server Gateway (auto-discovers DCC via capability index)
+  │
+  ▼
+PhotoshopMcpServer [Python sidecar]
+  │  WebSocket JSON-RPC (port 9001)
+  ▼
+UXP Plugin [JavaScript, runs inside Photoshop]
+  │  UXP API calls
+  ▼
+Adobe Photoshop 2022+
+```
+
+## Entry Strategy
+
+| Scenario | Path |
+|----------|------|
+| AI agent / CLI runtime | Gateway REST at `http://127.0.0.1:9765/mcp` — single endpoint for all DCCs |
+| IDE user (Cursor, Claude Desktop) | Configure `mcpServers` → `url: "http://127.0.0.1:9765/mcp"` |
+| Development / debugging | Embedded mode: `dcc-mcp-photoshop --embedded` (MCP server + bridge in one process) |
+
+## Skills-First Workflow
+
+When using Photoshop through dcc-mcp-photoshop, prefer skills over raw scripting:
+
+```
+1. SEARCH: search_skills(query="photoshop") → find available skill packages
+2. CHECK: Read the skill's SKILL.md description and tools
+3. LOAD:   load_skill("photoshop-document") → expose the tools
+4. CALL:   Call the specific tool with validated parameters
+5. FOLLOW UP: Check structured results for next steps
+```
+
+### Available Skills
+
+| Skill | Tools | Purpose |
+|-------|-------|---------|
+| `photoshop-setup` | 6 | Install, configure, verify bridge connection |
+| `photoshop-document` | 2 | Document info, list layers |
+| `photoshop-image` | 7 | Create document, export, resize, flatten, merge |
+| `photoshop-layers` | 8 | Layer CRUD, opacity, visibility, blend mode, fill |
+| `photoshop-text` | 3 | Create, update, inspect text layers |
+
+## CLI Modes
+
+| Mode | Command | Use Case |
+|------|---------|----------|
+| Bridge-only (default) | `dcc-mcp-photoshop` | Deployment with external `dcc-mcp-server` |
+| Embedded | `dcc-mcp-photoshop --embedded` | Development (MCP + bridge in one process) |
+| Daemon | `dcc-mcp-photoshop --daemon` | Non-interactive background startup |
+
+## Distribution Channels
+
+| Channel | Artifact | Python Required |
+|---------|----------|-----------------|
+| PyPI | `dcc-mcp-photoshop` wheel + sdist | Yes (3.8+) |
+| GitHub Release | Standalone binary (Win/Linux/Mac) | No |
+| GitHub Release | UXP `.ccx` plugin | No |
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `README.md` | Human-readable project documentation (EN) |
+| `README_zh.md` | Human-readable project documentation (ZH) |
+| `CHANGELOG.md` | Release history |
+| `docs/PRD.md` | Product Requirements Document |
+| `docs/bridge-protocol.md` | WebSocket JSON-RPC 2.0 bridge protocol spec |
+| `docs/distribution.md` | Distribution & release guide |
+| `src/dcc_mcp_photoshop/` | Python package source |
+| `bridge/uxp-plugin/` | UXP plugin (JavaScript, runs inside Photoshop) |
+
+## Response Language
+
+- Reply to the user in **Simplified Chinese** by default.
+- Keep all code, identifiers, commit messages, and file contents in **English**.
+
+## PR / Commit Rules
+
+- No AI-attribution footers in PR bodies or commit messages.
+- Rebase onto main before merging — no merge commits.
+- CI must pass before review.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,35 @@
+# CLAUDE.md — dcc-mcp-photoshop
+
+> Entry point for Anthropic Claude agents.
+> This file intentionally delegates to `AGENTS.md` so project rules stay single-sourced.
+> Do not copy detailed project guidance here — update `AGENTS.md` or `llms.txt` instead.
+
+## Read Order
+
+1. `AGENTS.md` — navigation map, available skills, and response rules.
+2. `llms.txt` — compact API index with all tools and CLI options.
+3. `docs/bridge-protocol.md` — WebSocket JSON-RPC protocol between Python bridge and UXP plugin.
+4. `docs/distribution.md` — distribution channels, release workflow.
+
+## Mandatory DCC Workflow
+
+When interacting with Adobe Photoshop through dcc-mcp-photoshop, use the Skills-First workflow described in `AGENTS.md`:
+1. `search_skills("photoshop")` → find available skills
+2. `load_skill("photoshop-<name>")` → load the skill
+3. Call the specific tool with validated parameters
+
+Do not use raw subprocess or adobe CLI calls.
+
+## Build & Test
+
+```bash
+# Install (editable)
+uv pip install -e .
+
+# Run tests
+uv run pytest
+
+# Format + lint
+uv run ruff format .
+uv run ruff check .
+```

--- a/bridge/uxp-plugin/README.md
+++ b/bridge/uxp-plugin/README.md
@@ -3,9 +3,8 @@
 This directory contains the Adobe UXP plugin that runs inside Photoshop and
 exposes a WebSocket server for the Python bridge to connect to.
 
-## Status
-
-> **Placeholder** — UXP plugin implementation is pending.
+The UXP plugin is bundled as a `.ccx` archive for distribution. See
+[`docs/distribution.md`](../../docs/distribution.md) for install instructions.
 
 ## Architecture
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,7 +1,7 @@
 # Product Requirements Document: dcc-mcp-photoshop
 
-**Version**: 0.1.0 (Placeholder)
-**Status**: Pre-Alpha
+**Version**: 0.1.x (Active)
+**Status**: Active Development — 16 releases shipped, 5 skill packages with 20+ MCP tools
 **Target**: Adobe Photoshop 2022+
 
 ---

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -46,7 +46,7 @@ No Python runtime required.
 
 ```bash
 # Download and run (example: Linux)
-curl -L https://github.com/dcc-mcp/dcc-mcp-photoshop/releases/download/v0.2.0/dcc-mcp-photoshop-linux \
+curl -L https://github.com/dcc-mcp/dcc-mcp-photoshop/releases/latest/download/dcc-mcp-photoshop-linux \
   -o dcc-mcp-photoshop
 chmod +x dcc-mcp-photoshop
 ./dcc-mcp-photoshop --help
@@ -71,12 +71,12 @@ server that the Python or binary bridge connects to.
 **Install manually (Windows):**
 ```powershell
 # Copy the .ccx to the system plugin directory
-copy dcc-mcp-photoshop-bridge-0.2.0.ccx "$env:APPDATA\Adobe\UXP\Plugins\External\"
+copy dcc-mcp-photoshop-bridge-<version>.ccx "$env:APPDATA\Adobe\UXP\Plugins\External\"
 ```
 
 **Install manually (macOS):**
 ```bash
-cp dcc-mcp-photoshop-bridge-0.2.0.ccx ~/Library/Application\ Support/Adobe/UXP/Plugins/External/
+cp dcc-mcp-photoshop-bridge-<version>.ccx ~/Library/Application\ Support/Adobe/UXP/Plugins/External/
 ```
 
 ---
@@ -132,7 +132,7 @@ The following table shows which versions of each component work together:
 | Photoshop Plugin (.ccx) | dcc-mcp-photoshop | dcc-mcp-core | Sidecar Binary |
 |-------------------------|-------------------|--------------|----------------|
 | 0.1.x | 0.1.x | >=0.12.14,<1.0.0 | dcc-mcp-server >=0.12.14 |
-| 0.2.x | 0.2.x | >=0.18.2,<1.0.0 | dcc-mcp-server >=0.18.2 |
+| 0.2.x | 0.2.x | >=0.18.14,<1.0.0 | dcc-mcp-server >=0.18.14 |
 
 Version alignment rules:
 
@@ -178,9 +178,9 @@ replaces the release assets.
 ### Artifact set per release
 
 ```
-dcc-mcp-photoshop-0.2.0-py3-none-any.whl          # Python wheel
-dcc-mcp-photoshop-0.2.0.tar.gz                       # Python sdist
-dcc-mcp-photoshop-bridge-0.2.0.ccx                   # UXP plugin
+dcc-mcp-photoshop-<version>-py3-none-any.whl          # Python wheel
+dcc-mcp-photoshop-<version>.tar.gz                       # Python sdist
+dcc-mcp-photoshop-bridge-<version>.ccx                   # UXP plugin
 dcc-mcp-photoshop-windows.exe                        # Windows binary
 dcc-mcp-photoshop-linux                              # Linux binary
 dcc-mcp-photoshop-macos                              # macOS binary

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,131 @@
+# dcc-mcp-photoshop
+
+> Adobe Photoshop adapter for the DCC MCP ecosystem: bridges MCP tools to Photoshop via UXP WebSocket.
+
+## Quick Start
+
+```
+# Start embedded dev server (bridge + MCP in one process)
+dcc-mcp-photoshop --embedded
+
+# Or with external dcc-mcp-server (deployment):
+# 1) Start dcc-mcp-server pointing to this DCC
+dcc-mcp-server --dcc photoshop --mcp-port 8765 --skill-paths ./skills --no-bridge
+# 2) Start the bridge
+dcc-mcp-photoshop
+
+# MCP client connects to:
+#   http://127.0.0.1:9765/mcp        (gateway, auto-routes to photoshop)
+#   http://127.0.0.1:8765/mcp        (direct per-DCC port)
+```
+
+## Agent Workflow
+
+```
+1. search_skills("photoshop")     → discover photoshop-* skills
+2. load_skill("photoshop-setup")  → expose setup tools
+3. (optional) check_environment   → verify Photoshop + bridge status
+4. load_skill("photoshop-document") → expose document tools
+5. get_document_info              → inspect active doc
+6. list_layers                    → list all layers
+7. load_skill("photoshop-layers")  → expose layer tools
+8. create_layer / set_layer_opacity / ... → manipulate layers
+```
+
+## Available Tools by Skill
+
+### photoshop-setup
+| Tool | Description |
+|------|-------------|
+| `check_environment` | Check system prerequisites |
+| `install_package` | Install/upgrade dcc-mcp-photoshop via pip |
+| `setup_uxp_plugin` | Install .ccx plugin into Photoshop |
+| `start_server` | Start embedded server for dev |
+| `verify_connection` | End-to-end bridge connection check |
+| `configure_mcp_client` | Auto-write MCP client config |
+
+### photoshop-document
+| Tool | Description |
+|------|-------------|
+| `get_document_info` | Active document metadata |
+| `list_layers` | List layers (optional hidden filter) |
+
+### photoshop-image
+| Tool | Description |
+|------|-------------|
+| `create_document` | New document with dimensions/resolution |
+| `export_document` | Export as PNG/JPG/TIFF/PSD |
+| `save_document` | Save in-place |
+| `resize_canvas` | Change canvas size without resampling |
+| `resize_image` | Scale image (resamples content) |
+| `flatten_image` | Flatten to single layer |
+| `merge_visible_layers` | Merge visible layers |
+
+### photoshop-layers
+| Tool | Description |
+|------|-------------|
+| `create_layer` | Create pixel/group/adjustment layer |
+| `delete_layer` | Delete a named layer |
+| `duplicate_layer` | Duplicate a layer |
+| `rename_layer` | Rename a layer |
+| `set_layer_opacity` | Set opacity 0-100 |
+| `set_layer_visibility` | Show/hide a layer |
+| `set_layer_blend_mode` | Set blend mode (normal, multiply, etc.) |
+| `fill_layer` | Fill with solid color or transparent |
+
+### photoshop-text
+| Tool | Description |
+|------|-------------|
+| `create_text_layer` | Create text layer with full styling |
+| `update_text_layer` | Update text content or style |
+| `get_text_layer_info` | Read text properties |
+
+## CLI Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--embedded` | false | MCP server + bridge in one process (dev only) |
+| `--daemon` | false | Non-interactive background startup |
+| `--bridge-only` | true | Bridge-only mode (for use with dcc-mcp-server) |
+| `--mcp-port` | 8765 | MCP HTTP server port (embedded mode) |
+| `--ws-port` | 9001 | WebSocket bridge port for UXP plugin |
+| `--ws-host` | localhost | WebSocket bind host |
+| `--rpc-port` | 9100 | HTTP RPC server port |
+| `--gateway-port` | 9765 | Gateway competition port (embedded mode) |
+| `--server-name` | photoshop-mcp | Server name reported in MCP |
+| `--skill-paths` | [] | Extra skill directories |
+| `--no-builtins` | false | Skip built-in skills |
+| `--verbose/-v` | false | Enable debug logging |
+
+## Architecture
+
+The Python process (dcc-mcp-photoshop) runs a WebSocket server on port 9001. The UXP JavaScript plugin inside Photoshop connects to it as a WebSocket client — this direction is required because UXP supports WebSocket client mode only.
+
+```json
+{
+  "mcpServers": {
+    "photoshop": {
+      "url": "http://127.0.0.1:9765/mcp"
+    }
+  }
+}
+```
+
+## Protocol
+
+Bridge communication uses JSON-RPC 2.0 over WebSocket. See `docs/bridge-protocol.md` for full specification.
+
+## Dependencies
+
+- `dcc-mcp-core>=0.18.14,<1.0.0`
+- `websockets>=12.0`
+- Python >=3.8
+- Adobe Photoshop 2022+
+
+## Distribution
+
+- **PyPI**: `pip install dcc-mcp-photoshop`
+- **Standalone binary**: GitHub Releases (no Python needed)
+- **UXP .ccx plugin**: GitHub Releases
+
+See `docs/distribution.md` for full details.


### PR DESCRIPTION
## Summary

Documentation patrol results for dcc-mcp-photoshop (v0.1.16). Adds missing agent-facing files and fixes stale version references.

### Changes

**New files:**
- `AGENTS.md` — Agent navigation map with skills overview, entry paths, available skills table, and PR/response rules (modeled after dcc-mcp-core pattern)
- `CLAUDE.md` — Claude Code entry point delegating to AGENTS.md
- `llms.txt` — LLM-oriented compact API reference with all 20+ tools, CLI flags, architecture, and quick-start guide

**Fixes:**
- `docs/distribution.md` — Replace hardcoded `v0.2.0` artifact references with `<version>` placeholders and `latest` download URLs; fix version compatibility matrix from `>=0.18.2` to `>=0.18.14` (matching pyproject.toml)
- `docs/PRD.md` — Update status from "Pre-Alpha" to "Active Development" with current release info
- `bridge/uxp-plugin/README.md` — Remove "Placeholder — implementation pending" banner; UXP plugin is implemented and shipping

### Motivation

These files bring dcc-mcp-photoshop up to the same agent-documentation standard as dcc-mcp-core, making it discoverable and usable by AI agents without manual README reading.

## Test plan

- [ ] CI checks pass
- [ ] Rendered markdown reviewed