### PR TITLE
fix: add pyoxidizer installation in release build-binary job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,9 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev]"
 
+      - name: Install PyOxidizer
+        run: pip install pyoxidizer
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 


### PR DESCRIPTION
## Problem

The release workflow `build-binary` job fails because PyOxidizer is not installed before running `tools/build_binary.py`.

Error from v0.1.17 release: `ERROR: PyOxidizer not found. Run: pip install pyoxidizer`

Run URL: https://github.com/dcc-mcp/dcc-mcp-photoshop/actions/runs/27577085698

## Fix

Added a `pip install pyoxidizer` step in the `build-binary` job, placed after project dependencies install and before the Rust toolchain setup.

## Verification

- `tools/build_binary.py` explicitly checks for pyoxidizer at line 36-45 via `_check_pyoxidizer()`
- `pyoxidizer.bzl` is the config file used by the build script
- This step is needed on all platforms (Windows, Linux, macOS) in the build matrix

Closes PIP-1656