### PR TITLE
fix: sync manifest.json version and add release version validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,9 +68,43 @@ jobs:
           echo "tag_name=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${VER}" >> "$GITHUB_OUTPUT"
 
+  # ── Validate release version against pyproject.toml ──────────────────────
+  validate-release-version:
+    needs: [decide]
+    if: github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && inputs.tag_name != '')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.decide.outputs.tag_name }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Validate release version
+        env:
+          RELEASE_VERSION: ${{ needs.decide.outputs.version }}
+        run: |
+          import os, sys, tomllib
+          from pathlib import Path
+
+          release_version = os.environ["RELEASE_VERSION"]
+          pyproject = tomllib.loads(Path("pyproject.toml").read_text())
+          project_version = pyproject["project"]["version"]
+
+          if project_version != release_version:
+              print(f"::error::pyproject.toml version {project_version} does not match release tag version {release_version}")
+              sys.exit(1)
+
+          print(f"Release version {release_version} matches pyproject.toml")
+        shell: python
+
   # ── Build standalone binary (per platform) ─────────────────────────────────
   build-binary:
-    needs: [decide]
+    needs: [decide, validate-release-version]
     if: github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && inputs.tag_name != '')
     strategy:
       matrix:
@@ -130,7 +164,7 @@ jobs:
   # ── Build wheel + sdist ──────────────────────────────────────────────────────
   build:
     name: Build wheel and sdist
-    needs: [decide]
+    needs: [decide, validate-release-version]
     if: github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && inputs.tag_name != '')
     runs-on: ubuntu-latest
     steps:
@@ -166,7 +200,7 @@ jobs:
 
   # ── Build UXP plugin .ccx ───────────────────────────────────────────────────
   build-uxp-plugin:
-    needs: [decide]
+    needs: [decide, validate-release-version]
     if: github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && inputs.tag_name != '')
     runs-on: ubuntu-latest
     steps:
@@ -207,7 +241,7 @@ jobs:
 
   # ── Publish to PyPI (tag push only, not on manual rebuild) ───────────────────
   publish:
-    needs: [decide, build]
+    needs: [decide, validate-release-version, build]
     if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     environment:
@@ -231,7 +265,7 @@ jobs:
 
   # ── Attach wheels + plugin + binaries to GitHub Release ─────────────────────
   attach-release-assets:
-    needs: [decide, build-uxp-plugin, build-binary]
+    needs: [decide, validate-release-version, build-uxp-plugin, build-binary]
     if: github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && inputs.tag_name != '')
     runs-on: ubuntu-latest
     permissions:

--- a/bridge/uxp-plugin/manifest.json
+++ b/bridge/uxp-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.dcc-mcp.photoshop-bridge",
   "name": "dcc-mcp Bridge",
-  "version": "0.1.0",
+  "version": "0.1.19",
   "manifestVersion": 5,
   "main": "index.html",
   "host": {


### PR DESCRIPTION
## Summary

Minor improvements to the release distribution pipeline for dcc-mcp-photoshop:

### Changes

1. **Sync manifest.json version**: Updated `bridge/uxp-plugin/manifest.json` version from `0.1.0` to `0.1.19` to match `pyproject.toml`. The CI already dynamically updates the version during `.ccx` packaging, but the source file should be consistent.

2. **Add release version validation**: Added a `validate-release-version` job to `.github/workflows/release.yml` that verifies `pyproject.toml` version matches the release tag before any build jobs run. This aligns with the dcc-mcp-core release workflow pattern and prevents publishing mismatched artifacts.

### Related

- Original issue: dcc-mcp-photoshop#6 — Package sidecar and UXP plugin for release distribution
- The existing release workflow already covers all distribution channels: PyPI wheel/sdist, standalone PyOxidizer binaries (Win/Linux/Mac), and UXP .ccx plugin

### Verification

- All 191 tests pass (5 skipped)
- Ruff lint and format checks pass
- Release workflow structure validated