### PR TITLE
fix: standalone binary build for dcc-mcp-photoshop (PyOxidizer fixes)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,12 +112,15 @@ jobs:
           - os: windows-latest
             artifact: dcc-mcp-photoshop-windows
             binary: dist/binary/dcc-mcp-photoshop.exe
+            binary_name: dcc-mcp-photoshop.exe
           - os: ubuntu-latest
             artifact: dcc-mcp-photoshop-linux
             binary: dist/binary/dcc-mcp-photoshop
+            binary_name: dcc-mcp-photoshop
           - os: macos-latest
             artifact: dcc-mcp-photoshop-macos
             binary: dist/binary/dcc-mcp-photoshop
+            binary_name: dcc-mcp-photoshop
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -147,19 +150,27 @@ jobs:
       - name: Smoke test — standalone binary
         shell: bash
         run: |
-          BINARY="${{ matrix.binary }}"
-          if [ ! -f "$BINARY" ]; then
-            echo "Binary not found: $BINARY"
+          cd dist/binary
+          if [ ! -f "${{ matrix.binary_name }}" ]; then
+            echo "Binary not found: ${{ matrix.binary_name }}"
             exit 1
           fi
-          "$BINARY" --version
-          "$BINARY" --help
+          "./${{ matrix.binary_name }}" --version
+          "./${{ matrix.binary_name }}" --help
 
-      - name: Upload binary artifact
+      - name: Package binary bundle (tar.gz)
+        shell: bash
+        run: |
+          mkdir -p dist/archive
+          cd dist/binary
+          tar czf "../archive/${{ matrix.artifact }}.tar.gz" .
+          echo "Created: $(ls -lh "../archive/${{ matrix.artifact }}.tar.gz")"
+
+      - name: Upload binary archive
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
-          path: ${{ matrix.binary }}
+          path: dist/archive/${{ matrix.artifact }}.tar.gz
 
   # ── Build wheel + sdist ──────────────────────────────────────────────────────
   build:
@@ -284,29 +295,29 @@ jobs:
           name: uxp-plugin
           path: dist/plugin/
 
-      - name: Download Windows binary
+      - name: Download Windows binary archive
         uses: actions/download-artifact@v4
         with:
           name: dcc-mcp-photoshop-windows
-          path: dist/binary/windows/
+          path: dist/bundle/
 
-      - name: Download Linux binary
+      - name: Download Linux binary archive
         uses: actions/download-artifact@v4
         with:
           name: dcc-mcp-photoshop-linux
-          path: dist/binary/linux/
+          path: dist/bundle/
 
-      - name: Download macOS binary
+      - name: Download macOS binary archive
         uses: actions/download-artifact@v4
         with:
           name: dcc-mcp-photoshop-macos
-          path: dist/binary/macos/
+          path: dist/bundle/
 
-      - name: Rename binaries with platform suffix
+      - name: Rename archives with platform prefix
         run: |
-          mv dist/binary/windows/dcc-mcp-photoshop.exe  dist/binary/dcc-mcp-photoshop-windows.exe  || true
-          mv dist/binary/linux/dcc-mcp-photoshop        dist/binary/dcc-mcp-photoshop-linux         || true
-          mv dist/binary/macos/dcc-mcp-photoshop        dist/binary/dcc-mcp-photoshop-macos         || true
+          mv dist/bundle/dcc-mcp-photoshop-windows.tar.gz  dist/dcc-mcp-photoshop-windows.tar.gz  || true
+          mv dist/bundle/dcc-mcp-photoshop-linux.tar.gz    dist/dcc-mcp-photoshop-linux.tar.gz    || true
+          mv dist/bundle/dcc-mcp-photoshop-macos.tar.gz    dist/dcc-mcp-photoshop-macos.tar.gz    || true
 
       - name: Attach all assets to GitHub Release
         uses: softprops/action-gh-release@v2
@@ -316,6 +327,3 @@ jobs:
             dist/*.whl
             dist/*.tar.gz
             dist/plugin/*.ccx
-            dist/binary/dcc-mcp-photoshop-*.exe
-            dist/binary/dcc-mcp-photoshop-linux
-            dist/binary/dcc-mcp-photoshop-macos

--- a/pyoxidizer.bzl
+++ b/pyoxidizer.bzl
@@ -13,12 +13,19 @@ def make_exe():
     # Configure packaging policy.
     policy = dist.make_python_packaging_policy()
 
-    # Fall back to loading resources from a "lib" directory next to the binary
-    # when in-memory loading fails.
-    policy.resources_location_fallback = "filesystem-relative:lib"
+    # Load all Python resources from the "lib" directory next to the binary.
+    # Filesystem-relative mode sets __file__, which many packages (including
+    # dcc-mcp-core) depend on.  In-memory mode breaks __file__ usage.
+    policy.resources_location = "filesystem-relative:lib"
 
     # Configure the embedded Python interpreter.
     python_config = dist.make_python_interpreter_config()
+
+    # Use the standard Python filesystem importer instead of the oxidized
+    # importer.  The standard importer handles init_fs_encoding correctly
+    # and sets __file__ for all loaded modules.
+    python_config.oxidized_importer = False
+    python_config.filesystem_importer = True
 
     # Set module search path so the interpreter can find installed packages.
     python_config.module_search_paths = ["$ORIGIN/lib"]
@@ -26,8 +33,9 @@ def make_exe():
     # Run dcc_mcp_photoshop.cli as __main__ when the binary starts.
     python_config.run_module = "dcc_mcp_photoshop.cli"
 
-    # Forward command-line arguments to the Python program.
-    python_config.parse_argv = True
+    # Don't let CPython's arg parser intercept --help/--version.
+    # Our CLI argparse handles all args after Python is fully initialized.
+    python_config.parse_argv = False
 
     # Produce a PythonExecutable from the distribution, embedded resources,
     # and the configuration above.

--- a/tools/build_binary.py
+++ b/tools/build_binary.py
@@ -37,7 +37,7 @@ def _check_pyoxidizer() -> None:
     """Verify PyOxidizer is installed and accessible."""
     try:
         subprocess.run(
-            [sys.executable, "-m", "pyoxidizer", "--version"],
+            ["pyoxidizer", "--version"],
             capture_output=True, check=True, text=True,
         )
     except (subprocess.CalledProcessError, FileNotFoundError):
@@ -72,6 +72,34 @@ def _find_binary(build_dir: Path) -> Path | None:
     return None
 
 
+def _copy_runtime_dlls(src_dir: Path, dst_dir: Path) -> None:
+    """Copy runtime DLLs (python*.dll, vcruntime*.dll) alongside the binary.
+
+    PyOxidizer shared builds on Windows place python3.dll, python*.dll, and
+    VC++ redist DLLs next to the binary.  Copy them so the binary can be run
+    from the output directory without requiring those paths in PATH.
+    """
+    if sys.platform != "win32":
+        return
+    for dll in src_dir.glob("*.dll"):
+        shutil.copy2(dll, dst_dir / dll.name)
+
+
+def _copy_lib_dir(src_dir: Path, dst_dir: Path) -> None:
+    """Copy the lib/ directory containing Python stdlib and site-packages.
+
+    PyOxidizer places all Python resources (stdlib, dependencies, our package)
+    into a lib/ subdirectory next to the binary.  The binary's sys.path is
+    configured to look at ``$ORIGIN/lib``.
+    """
+    src_lib = src_dir / "lib"
+    dst_lib = dst_dir / "lib"
+    if src_lib.is_dir():
+        if dst_lib.exists():
+            shutil.rmtree(dst_lib)
+        shutil.copytree(src_lib, dst_lib, ignore=shutil.ignore_patterns("__pycache__"))
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Build the dcc-mcp-photoshop standalone binary using PyOxidizer",
@@ -102,7 +130,7 @@ def main() -> None:
     print()
 
     cmd = [
-        sys.executable, "-m", "pyoxidizer", "build",
+        "pyoxidizer", "build",
         "--path", str(PROJECT_ROOT),
     ]
 
@@ -140,9 +168,22 @@ def main() -> None:
     dest = output_dir / binary.name
     shutil.copy2(binary, dest)
 
+    # Copy runtime DLLs and Python stdlib/site-packages lib/ directory.
+    _copy_runtime_dlls(binary.parent, output_dir)
+    _copy_lib_dir(binary.parent, output_dir)
+
     size_mb = dest.stat().st_size / 1_048_576
     print(f"\nBuild complete!")
     print(f"  Binary: {dest}  ({size_mb:.1f} MB)")
+    if sys.platform == "win32":
+        dlls = list(output_dir.glob("*.dll"))
+        if dlls:
+            dll_size = sum(f.stat().st_size for f in dlls) / 1_048_576
+            print(f"  Runtime DLLs ({len(dlls)} files, {dll_size:.1f} MB total)")
+        lib_dir = output_dir / "lib"
+        if lib_dir.is_dir():
+            lib_size = sum(f.stat().st_size for f in lib_dir.rglob("*") if f.is_file()) / 1_048_576
+            print(f"  Python lib  : {lib_dir}  ({lib_size:.1f} MB)")
     print()
     print("Usage:")
     print(f"  {dest.name} --help")


### PR DESCRIPTION
## Summary

修复 dcc-mcp-photoshop standalone binary 构建中的三个核心问题：

1. **PyOxidizer CLI 兼容性** — `pyoxidizer` 安装为 CLI 脚本而非 Python 模块，构建脚本改用 `pyoxidizer` 直接调用
2. **`--version` / `--help` 拦截** — `parse_argv=True` 让 CPython 拦截了参数；改为 `False`，让 `cli.py` 的 argparse 处理
3. **`__file__` 不可用** — 默认内存模式不设 `__file__`，导致 `dcc_mcp_core.skill` 崩溃；切换为 `filesystem-relative:lib` + 标准 filesystem importer

## CI 变更

binary 构建产物从单文件改为完整运行包（tar.gz），包含：
- `dcc-mcp-photoshop.exe`（~5.5 MB）
- 运行时 DLL（Windows，~4.5 MB）
- Python stdlib + deps `lib/` 目录（~82 MB）

## 验证

- `dist/binary/dcc-mcp-photoshop.exe --version` — 输出正确版本号
- `dist/binary/dcc-mcp-photoshop.exe --help` — 显示自定义 argparse 帮助
- 完整 daemon 启动：MCP server、WebSocket bridge、RPC 均正常初始化
- Skills（5 built-in + 5 from dcc_mcp_core）正确发现
- 191 tests passed, 5 skipped — 无回归