### PR TITLE
fix(ci): handle missing bridge/uxp-plugin in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,32 +219,49 @@ jobs:
         with:
           ref: ${{ needs.decide.outputs.tag_name }}
 
+      - name: Check if bridge/uxp-plugin exists
+        id: check
+        run: |
+          if [ -d "bridge/uxp-plugin" ] && [ -f "bridge/uxp-plugin/manifest.json" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "bridge/uxp-plugin directory not found — skipping UXP plugin build"
+          fi
+
       - name: Set up Python 3.12
+        if: steps.check.outputs.exists == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Install dcc-mcp-core (for version detection)
+        if: steps.check.outputs.exists == 'true'
         run: pip install dcc-mcp-core
 
       - name: Download dcc-mcp-server Windows binary from dcc-mcp-core release
+        if: steps.check.outputs.exists == 'true'
         run: python tools/download_dcc_mcp_server.py --platform windows
 
       - name: Stage sidecar into UXP plugin tree
+        if: steps.check.outputs.exists == 'true'
         run: python tools/stage_plugin_sidecar.py
 
       - name: Pack UXP plugin (.ccx)
+        if: steps.check.outputs.exists == 'true'
         run: |
           python tools/pack_plugin.py --version "${{ needs.decide.outputs.version }}" --output dist/plugin
         shell: bash
 
       - name: Verify .ccx file was created
+        if: steps.check.outputs.exists == 'true'
         shell: bash
         run: |
           ls -la dist/plugin/
           test -n "$(find dist/plugin/ -name '*.ccx' -print -quit)"
 
       - name: Upload plugin artifact
+        if: steps.check.outputs.exists == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: uxp-plugin
@@ -291,6 +308,7 @@ jobs:
 
       - name: Download UXP plugin artifact
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: uxp-plugin
           path: dist/plugin/
@@ -327,3 +345,4 @@ jobs:
             dist/*.whl
             dist/*.tar.gz
             dist/plugin/*.ccx
+          fail_on_unmatched_files: false


### PR DESCRIPTION
## Summary

The UXP plugin (`bridge/uxp-plugin/`) was intentionally removed in a prior commit as the project migrated to adobepy broker architecture. However, the release workflow's `build-uxp-plugin` job was not updated and failed with 'manifest.json not found' during the v0.1.21 release.

## Root Cause

- `bridge/uxp-plugin/manifest.json` was deleted as part of the architecture migration
- `release.yml` `build-uxp-plugin` job unconditionally tries to pack the plugin
- `pack_plugin.py` exits with error when manifest.json is missing

## Fix

1. **Add guard check** in `build-uxp-plugin` job — checks if `bridge/uxp-plugin` and `manifest.json` exist before running UXP build steps (same pattern as `ci.yml`)
2. **`continue-on-error: true`** for UXP plugin artifact download in `attach-release-assets` — prevents the attach job from failing when UXP plugin wasn't built
3. **`fail_on_unmatched_files: false`** for the `softprops/action-gh-release` step — graceful when `.ccx` files don't exist

## Affected

- Release workflow for future version tags
- No impact on existing releases or the PyPI publish pipeline