### PR TITLE
chore: bump dcc-mcp-core to >=0.18.34

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 
 dependencies = [
     "adobepy>=0.1.0",
-    "dcc-mcp-core>=0.18.14,<1.0.0",
+    "dcc-mcp-core>=0.18.34,<1.0.0",
     "websockets>=12.0",
 ]
 


### PR DESCRIPTION
Bump dcc-mcp-core minimum version from >=0.18.14 to >=0.18.34. No breaking changes. Part of PIP-1820.