### PR TITLE
fix: replace hardcoded version assertion with dynamic semver check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Start server briefly and verify it responds
         run: |
-          dcc-mcp-photoshop --port 0 --no-broker-check &
+          dcc-mcp-photoshop --mcp-port 0 &
           SERVER_PID=$!
           sleep 2
           kill $SERVER_PID 2>/dev/null || true

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -8,7 +8,12 @@ import pytest
 def test_import():
     import dcc_mcp_photoshop
 
-    assert dcc_mcp_photoshop.__version__ == "0.1.24"
+    assert dcc_mcp_photoshop.__version__
+    # Verify semver format (major.minor.patch) — never pin exact version;
+    # release-please bumps trigger CI failures on hardcoded assertions.
+    parts = dcc_mcp_photoshop.__version__.split(".")
+    assert len(parts) == 3, f"Expected semver, got {dcc_mcp_photoshop.__version__}"
+    assert all(p.isdigit() for p in parts), f"Version parts must be numeric: {parts}"
 
 
 def test_api_imports():


### PR DESCRIPTION
## Summary
- Replace `assert __version__ == "0.1.24"` in `tests/test_server.py` with dynamic semver format validation — survives any release-please version bump
- Fix CLI smoke test in CI: `--port` → `--mcp-port`, remove nonexistent `--no-broker-check`

## Root Cause
Release-please bumped version from 0.1.24 to 0.1.25, causing all 15 CI test jobs to fail because `test_server.py:11` had a hardcoded exact-version assertion. Additionally, the CLI was refactored and smoke test parameters were stale.

## Validation
- All 191 tests pass (0 failures, 5 skipped)
- `dcc-mcp-photoshop --help` confirms `--mcp-port` flag
- No other hardcoded version assertions found in tests/