### PR TITLE
fix: bump dcc-mcp-core to >=0.19.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 
 dependencies = [
     "adobepy>=0.1.0",
-    "dcc-mcp-core>=0.18.34,<1.0.0",
+    "dcc-mcp-core>=0.19.8,<1.0.0",
     "websockets>=12.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 
 dependencies = [
     "adobepy>=0.1.0",
-    "dcc-mcp-core>=0.19.8,<1.0.0",
+    "dcc-mcp-core>=0.19.9,<1.0.0",
     "websockets>=12.0",
 ]
 

--- a/src/dcc_mcp_photoshop/server.py
+++ b/src/dcc_mcp_photoshop/server.py
@@ -107,7 +107,7 @@ class PhotoshopMcpServer(DccServerBase):
         strict_skill_scan: bool | None = None,
         enable_gateway_failover: bool | None = None,
     ) -> None:
-        self._config = config or PhotoshopMcpConfig.from_env()
+        self._adapter_config = config or PhotoshopMcpConfig.from_env()
         self._startup_state = StartupState()
 
         # Resolve env-based configuration
@@ -123,10 +123,10 @@ class PhotoshopMcpServer(DccServerBase):
         options = DccServerOptions.from_env(
             dcc_name="photoshop",
             builtin_skills_dir=_BUILTIN_SKILLS_DIR,
-            port=port if port is not None else self._config.mcp_port,
+            port=port if port is not None else self._adapter_config.mcp_port,
             server_name=server_name,
             server_version=server_version,
-            gateway_port=gateway_port if gateway_port is not None else self._config.gateway_port,
+            gateway_port=gateway_port if gateway_port is not None else self._adapter_config.gateway_port,
         )
         super().__init__(options=options)
 
@@ -150,27 +150,27 @@ class PhotoshopMcpServer(DccServerBase):
             from adobe.core.client import BrokerClient  # noqa: PLC0415
 
             client = BrokerClient(
-                broker_url=self._config.broker_url,
-                token=self._config.broker_token,
-                timeout=self._config.timeout,
+                broker_url=self._adapter_config.broker_url,
+                token=self._adapter_config.broker_token,
+                timeout=self._adapter_config.timeout,
             )
             caps = client.capabilities()
             self._startup_state.stage = "broker_ready"
             logger.info(
                 "adobepy broker available at %s (target=%s)",
-                self._config.broker_url,
-                caps.get("target", self._config.broker_target),
+                self._adapter_config.broker_url,
+                caps.get("target", self._adapter_config.broker_target),
             )
         except Exception as exc:
             self._startup_state.set_failed(
                 "broker_check",
-                f"adobepy broker not reachable at {self._config.broker_url}: {exc}. "
+                f"adobepy broker not reachable at {self._adapter_config.broker_url}: {exc}. "
                 "Start the broker with 'adobepy broker' and ensure the UXP bridge is loaded.",
             )
             logger.warning(
                 "adobepy broker not reachable at %s: %s — "
                 "skill calls will fail until the broker and UXP bridge are running",
-                self._config.broker_url,
+                self._adapter_config.broker_url,
                 exc,
             )
 


### PR DESCRIPTION
## Summary

- Raise `dcc-mcp-core` dependency floor from `>=0.18.34,<1.0.0` to `>=0.19.8,<1.0.0`.
- Fix adapter startup on core 0.19.8 by storing Photoshop settings on `_adapter_config` instead of `_config`, which `DccServerBase` now uses for `McpHttpConfig`.

## Test plan

- [x] Host import: `dcc_mcp_core` 0.19.8 + `dcc_mcp_photoshop` 0.1.25
- [x] Unit tests: `pytest tests/` — 189 passed, 5 skipped
- [x] Local MCP smoke: `vx mcpcall doctor` + `search_skills(query=photoshop)` against `http://127.0.0.1:8877/mcp`
- [ ] CI: blocked until `dcc-mcp-core==0.19.8` appears on PyPI (GitHub release wheels exist; PyPI latest is still 0.19.7)
- [ ] Full Photoshop host tool call (`get_document_info`) pending adobepy broker + UXP bridge on this workstation

## Local test matrix

| Layer | Version / endpoint | Command | Result |
| --- | --- | --- | --- |
| Python | 3.12.10 | `pip install -e ".[dev]"` | pass |
| dcc-mcp-core | 0.19.8 | `import dcc_mcp_core` | pass |
| dcc-mcp-photoshop | 0.1.25 (editable) | `import dcc_mcp_photoshop` | pass |
| MCP server | `http://127.0.0.1:8877/mcp` | `python -m dcc_mcp_photoshop --mcp-port 8877` | pass (broker offline warning only) |
| Read-only tool | `search_skills` | `vx mcpcall call ... search_skills --arg query=photoshop` | pass |