### PR TITLE
[codex] Bundle current dcc-mcp core train

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The Python MCP server communicates with Photoshop through the adobepy Rust broke
 [![Python](https://img.shields.io/pypi/pyversions/dcc-mcp-photoshop?label=Python)](https://pypi.org/project/dcc-mcp-photoshop/)
 [![Photoshop](https://img.shields.io/badge/Photoshop-2022%2B-001E36)](https://www.adobe.com/products/photoshop.html)
 [![MCP](https://img.shields.io/badge/MCP-Streamable%20HTTP-6f42c1)](https://modelcontextprotocol.io/)
-[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.18.14-blue)](https://github.com/dcc-mcp/dcc-mcp-core)
+[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.19.17-blue)](https://github.com/dcc-mcp/dcc-mcp-core)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ## Why Use It
@@ -613,7 +613,7 @@ pytest tests/
 - **Photoshop**: Adobe Photoshop 2022+ (UXP support required)
 - **Python** (pip path only): Python 3.8+
 - **Dependencies** (auto-installed with pip):
-  - `dcc-mcp-core >= 0.18.14, < 1.0.0`
+  - `dcc-mcp-core >= 0.19.17, < 1.0.0`
   - `adobepy >= 0.1.0`
   - `websockets >= 12.0`
 - **Build** (to build standalone binary from source): Python 3.8+, [Rust toolchain](https://rustup.rs/), and PyOxidizer (`pip install pyoxidizer`)
@@ -628,7 +628,8 @@ pytest tests/
 
 | dcc-mcp-photoshop | dcc-mcp-core | UXP Plugin | Sidecar Binary |
 |-------------------|-------------|------------|----------------|
-| 0.1.x | >=0.12.14,<1.0.0 | 0.1.x | dcc-mcp-server >=0.12.14 |
+| current main | >=0.19.17,<1.0.0 | 0.1.x | dcc-mcp-server >=0.19.17 |
+| 0.1.0-0.1.26 | >=0.12.14,<1.0.0 | 0.1.x | dcc-mcp-server >=0.12.14 |
 | 0.2.x (planned) | >=0.18.2,<1.0.0 | 0.2.x | dcc-mcp-server >=0.18.2 |
 
 ## Distribution

--- a/README_zh.md
+++ b/README_zh.md
@@ -384,7 +384,7 @@ pytest tests/
 - **Photoshop**：Adobe Photoshop 2022+（需要 UXP 支持）
 - **Python**（pip 安装方式）：Python 3.8+
 - **依赖**（pip 自动安装）：
-  - `dcc-mcp-core >= 0.18.14, < 1.0.0`
+  - `dcc-mcp-core >= 0.19.17, < 1.0.0`
   - `adobepy >= 0.1.0`
   - `websockets >= 12.0`
 
@@ -392,7 +392,8 @@ pytest tests/
 
 | dcc-mcp-photoshop | dcc-mcp-core | UXP 插件 | Sidecar 二进制 |
 |-------------------|-------------|----------|----------------|
-| 0.1.x | >=0.12.14,<1.0.0 | 0.1.x | dcc-mcp-server >=0.12.14 |
+| current main | >=0.19.17,<1.0.0 | 0.1.x | dcc-mcp-server >=0.19.17 |
+| 0.1.0-0.1.26 | >=0.12.14,<1.0.0 | 0.1.x | dcc-mcp-server >=0.12.14 |
 | 0.2.x（计划中） | >=0.18.2,<1.0.0 | 0.2.x | dcc-mcp-server >=0.18.2 |
 
 ## 常见问题

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -177,7 +177,8 @@ The following table shows which versions of each component work together:
 
 | Photoshop Plugin (.ccx) | dcc-mcp-photoshop | dcc-mcp-core | Sidecar Binary |
 |-------------------------|-------------------|--------------|----------------|
-| 0.1.x | 0.1.x | >=0.12.14,<1.0.0 | dcc-mcp-server >=0.12.14 |
+| current main | current main | >=0.19.17,<1.0.0 | dcc-mcp-server >=0.19.17 |
+| 0.1.x through 0.1.26 | 0.1.x through 0.1.26 | >=0.12.14,<1.0.0 | dcc-mcp-server >=0.12.14 |
 | 0.2.x | 0.2.x | >=0.18.14,<1.0.0 | dcc-mcp-server >=0.18.14 |
 
 Version alignment rules:

--- a/llms.txt
+++ b/llms.txt
@@ -117,7 +117,7 @@ Bridge communication uses JSON-RPC 2.0 over WebSocket. See `docs/bridge-protocol
 
 ## Dependencies
 
-- `dcc-mcp-core>=0.18.14,<1.0.0`
+- `dcc-mcp-core>=0.19.17,<1.0.0`
 - `websockets>=12.0`
 - Python >=3.8
 - Adobe Photoshop 2022+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 
 dependencies = [
     "adobepy>=0.1.0",
-    "dcc-mcp-core>=0.19.9,<1.0.0",
+    "dcc-mcp-core>=0.19.17,<1.0.0",
     "websockets>=12.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -8,12 +8,12 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "altgraph"
-version = "0.17.5"
+name = "adobepy"
+version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7e/f8/97fdf103f38fed6792a1601dbc16cc8aac56e7459a9fff08c812d8ae177a/altgraph-0.17.5.tar.gz", hash = "sha256:c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7", size = 48428, upload-time = "2025-11-21T20:35:50.583Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/f6/270c0d5683e404352cf3cc2572463e52149e6406f60c0601f783a209a441/adobepy-0.1.0.tar.gz", hash = "sha256:89ea7770e4b37bf7826831513e2d650fdee4b51887f524c5d6ff1991b8a3f3ba", size = 40229, upload-time = "2026-05-31T14:36:49.783Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl", hash = "sha256:f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597", size = 21228, upload-time = "2025-11-21T20:35:49.444Z" },
+    { url = "https://files.pythonhosted.org/packages/69/96/7f4a895f6fe22aa9f6cfe74bc7e5584ed16ed542eef712b845c4254c1ab8/adobepy-0.1.0-py3-none-any.whl", hash = "sha256:cae1de68a4cb33e2abf32cda076ddffb1e65a0fee040d5d3d1e7d8892c699d9d", size = 46343, upload-time = "2026-05-31T14:36:48.601Z" },
 ]
 
 [[package]]
@@ -76,20 +76,25 @@ wheels = [
 
 [[package]]
 name = "dcc-mcp-core"
-version = "0.12.18"
+version = "0.19.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/70/e9/ae1ad8cd9295b12dbf4ec24d63b1acc210c2c84925097e659488011884ea/dcc_mcp_core-0.12.18.tar.gz", hash = "sha256:a7c2cebd1ad719220869f0666ff6af8f9d1214c24dca8a7f3ce05e358bd40569", size = 1249398, upload-time = "2026-04-12T12:29:33.098Z" }
+dependencies = [
+    { name = "dcc-mcp-server" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/83/e7235453e81bd973ad97560ca27d501eef2b68455bd5870e397b04d713f1/dcc_mcp_core-0.19.17.tar.gz", hash = "sha256:58e14520f52d27d73a46bca2b22e162f1da0481f4426256c41d70dfbf2f480f1", size = 5870800, upload-time = "2026-07-08T11:21:55.424Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/5f/6aab420a5b280265bd5d82a9c9952f0655dd5700c46d9af76f858c9621c0/dcc_mcp_core-0.12.18-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:0077efdb7e6dc7d5f7baa6a740ad6f2ec4392015c0d1e66e09152c30573c3eb2", size = 6925894, upload-time = "2026-04-12T12:29:27.724Z" },
-    { url = "https://files.pythonhosted.org/packages/da/60/e12a6a8b6ee8960758082f9d047e4ac7568b72e7d4daeb75159dc3fc3d59/dcc_mcp_core-0.12.18-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1861639392ed3b3b9a6043b3256567f32213dbf18830e4e376052a38c3851af4", size = 3756622, upload-time = "2026-04-12T12:29:29.81Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/00/3ec407e21ebb211e64201d41b6f943648751a2069f066bcde2465de5ad9f/dcc_mcp_core-0.12.18-cp38-abi3-win_amd64.whl", hash = "sha256:ef3375ab0ec3dfa2020035b33f71d83cd50fa7526d87a5e37ab80774fd29244f", size = 3870326, upload-time = "2026-04-12T12:29:31.662Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/48/714f5ba25b41c456278010c27ca40e348957428fbfbc2edd60193321561f/dcc_mcp_core-0.19.17-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:a3951481614306ca1b64d8f8d2f8471f335a5ec5718ae9217859f2392678961f", size = 34848830, upload-time = "2026-07-08T11:21:42.522Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/3c/a581d1d6ed38b1b16d83742470965cfc5e92e898ede0acbbcfbd3acb0bbb/dcc_mcp_core-0.19.17-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5363db8a94c9369056d01c63a96b0eb0da34da707934be14794d80d53d652ebc", size = 18810540, upload-time = "2026-07-08T11:21:46.513Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/76/3b9aca3afe5a544c860cd912f42c5ec7df05692c7c8e4de5d0c28e81832b/dcc_mcp_core-0.19.17-cp38-abi3-win_amd64.whl", hash = "sha256:c704d9aae0e6fa288ffb38c5553e358eb941552c14c217c709cd750e03bc594a", size = 18465350, upload-time = "2026-07-08T11:21:50.532Z" },
+    { url = "https://files.pythonhosted.org/packages/77/17/3e504fa9bcb996f366daa2b7669ed21aa7727b5f606e5a03ac704a044f10/dcc_mcp_core-0.19.17-py3-none-any.whl", hash = "sha256:506f93961c09254a2064b79529c9a05bd728cbccf2085d08f594a733d39dd5a0", size = 449795, upload-time = "2026-07-08T11:21:53.443Z" },
 ]
 
 [[package]]
 name = "dcc-mcp-photoshop"
-version = "0.1.0"
+version = "0.1.26"
 source = { editable = "." }
 dependencies = [
+    { name = "adobepy" },
     { name = "dcc-mcp-core" },
     { name = "websockets", version = "13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "websockets", version = "15.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
@@ -104,7 +109,7 @@ dev = [
     { name = "hatchling", version = "1.29.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyfakefs", version = "5.10.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pyfakefs", version = "6.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pyinstaller" },
+    { name = "pyoxidizer" },
     { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
     { name = "pytest", version = "9.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -119,11 +124,12 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "adobepy", specifier = ">=0.1.0" },
     { name = "build", marker = "extra == 'dev'" },
-    { name = "dcc-mcp-core", specifier = ">=0.12.18,<1.0.0" },
+    { name = "dcc-mcp-core", specifier = ">=0.19.17,<1.0.0" },
     { name = "hatchling", marker = "extra == 'dev'" },
     { name = "pyfakefs", marker = "extra == 'dev'", specifier = ">=5.3" },
-    { name = "pyinstaller", marker = "extra == 'dev'", specifier = ">=6.0" },
+    { name = "pyoxidizer", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.0" },
@@ -132,6 +138,16 @@ requires-dist = [
     { name = "websockets", specifier = ">=12.0" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "dcc-mcp-server"
+version = "0.19.17"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/66/3ee8d34a2f2e0b0f1b8ad06d1830ab39f42385df08ad5106262177f3d557/dcc_mcp_server-0.19.17-py3-none-macosx_10_12_universal2.macosx_10_12_x86_64.macosx_11_0_arm64.whl", hash = "sha256:2518dc9536d6d1243c11f974abf8a9c9bfc0a21d8798ee1c850908d5fd0bc54e", size = 33215462, upload-time = "2026-07-08T10:44:23.725Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cf/39ea0e11889dce7a9896b6980f390d58f3350a3d7d8cb0e010a17c5550e9/dcc_mcp_server-0.19.17-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ecb36c8ab23b8d88ca477a5a0420720140e14933ab52deaba412a54e62be299c", size = 17197102, upload-time = "2026-07-08T10:44:27.834Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/1d/ea2eed285be0569ff0b5daafce561e00263e5f4a1d45226407c7c3230c5e/dcc_mcp_server-0.19.17-py3-none-win_amd64.whl", hash = "sha256:42647b8727b35420976eec2dc294653500bfdc702e3ac4f4738cc43911eb7b82", size = 16002451, upload-time = "2026-07-08T10:44:31.929Z" },
+]
 
 [[package]]
 name = "exceptiongroup"
@@ -258,18 +274,6 @@ wheels = [
 ]
 
 [[package]]
-name = "macholib"
-version = "1.16.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "altgraph" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/d1/a9f36f8ecdf0fb7c9b1e78c8d7af12b8c8754e74851ac7b94a8305540fc7/macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea", size = 38117, upload-time = "2025-11-22T08:28:36.939Z" },
-]
-
-[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -301,15 +305,6 @@ resolution-markers = [
 sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
-]
-
-[[package]]
-name = "pefile"
-version = "2024.8.26"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
 ]
 
 [[package]]
@@ -372,50 +367,16 @@ wheels = [
 ]
 
 [[package]]
-name = "pyinstaller"
-version = "6.19.0"
+name = "pyoxidizer"
+version = "0.24.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "altgraph" },
-    { name = "importlib-metadata", version = "8.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "importlib-metadata", version = "8.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
-    { name = "macholib", marker = "sys_platform == 'darwin'" },
-    { name = "packaging" },
-    { name = "pefile", marker = "sys_platform == 'win32'" },
-    { name = "pyinstaller-hooks-contrib" },
-    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
-    { name = "setuptools", version = "75.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c8/63/fd62472b6371d89dc138d40c36d87a50dc2de18a035803bbdc376b4ffac4/pyinstaller-6.19.0.tar.gz", hash = "sha256:ec73aeb8bd9b7f2f1240d328a4542e90b3c6e6fbc106014778431c616592a865", size = 4036072, upload-time = "2026-02-14T18:06:28.718Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/eb/23374721fecfa72677e79800921cb6aceefa6ba48574dc404f3f6c6c3be7/pyinstaller-6.19.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:4190e76b74f0c4b5c5f11ac360928cd2e36ec8e3194d437bf6b8648c7bc0c134", size = 1040563, upload-time = "2026-02-14T18:05:22.436Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/7e/dfd724b0b533f5aaec0ee5df406fe2319987ed6964480a706f85478b12ea/pyinstaller-6.19.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8bd68abd812d8a6ba33b9f1810e91fee0f325969733721b78151f0065319ca11", size = 735477, upload-time = "2026-02-14T18:05:27.143Z" },
-    { url = "https://files.pythonhosted.org/packages/88/c9/ee3a4101c31f26344e66896c73c1fd6ed8282bf871473365b7f8674af406/pyinstaller-6.19.0-py3-none-manylinux2014_i686.whl", hash = "sha256:1ec54ef967996ca61dacba676227e2b23219878ccce5ee9d6f3aada7b8ed8abf", size = 747143, upload-time = "2026-02-14T18:05:31.488Z" },
-    { url = "https://files.pythonhosted.org/packages/da/0a/fc77e9f861be8cf300ac37155f59cc92aff99b29f2ddd78546f563a5b5a6/pyinstaller-6.19.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:4ab2bb52e58448e14ddf9450601bdedd66800465043501c1d8f1cab87b60b122", size = 744849, upload-time = "2026-02-14T18:05:35.492Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/e3/6872e020ee758afe0b821663858492c10745608b07150e5e2c824a5b3e1c/pyinstaller-6.19.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:da6d5c6391ccefe73554b9fa29b86001c8e378e0f20c2a4004f836ba537eff63", size = 741590, upload-time = "2026-02-14T18:05:39.59Z" },
-    { url = "https://files.pythonhosted.org/packages/53/60/b8db5f1a4b0fb228175f2ea0aa33f949adcc097fbe981cc524f9faf85777/pyinstaller-6.19.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a0fc5f6b3c55aa54353f0c74ffa59b1115433c1850c6f655d62b461a2ed6cbbe", size = 741448, upload-time = "2026-02-14T18:05:45.636Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/4d/63b0600f2694e9141b83129fbc1c488ec84d5a0770b1448ec154dcd0fee9/pyinstaller-6.19.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:e649ba6bd1b0b89b210ad92adb5fbdc8a42dd2c5ca4f72ef3a0bfec83a424b83", size = 740613, upload-time = "2026-02-14T18:05:49.726Z" },
-    { url = "https://files.pythonhosted.org/packages/01/d4/e812ad36178093a0e9fd4b8127577748dd85b0cb71de912229dca21fd741/pyinstaller-6.19.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:481a909c8e60c8692fc60fcb1344d984b44b943f8bc9682f2fcdae305ad297e6", size = 740350, upload-time = "2026-02-14T18:05:54.093Z" },
-    { url = "https://files.pythonhosted.org/packages/52/03/b2c2ee41fb8e10fd2a45d21f5ec2ef25852cfb978dbf762972eed59e3d63/pyinstaller-6.19.0-py3-none-win32.whl", hash = "sha256:3c5c251054fe4cfaa04c34a363dcfbf811545438cb7198304cd444756bc2edd2", size = 1324317, upload-time = "2026-02-14T18:06:00.085Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/d3/6d5e62b8270e2b53a6065e281b3a7785079b00e9019c8019952828dd1669/pyinstaller-6.19.0-py3-none-win_amd64.whl", hash = "sha256:b5bb6536c6560330d364d91522250f254b107cf69129d9cbcd0e6727c570be33", size = 1384894, upload-time = "2026-02-14T18:06:06.425Z" },
-    { url = "https://files.pythonhosted.org/packages/81/65/458cd523308a101a22fd2742893405030cc24994cc74b1b767cecf137160/pyinstaller-6.19.0-py3-none-win_arm64.whl", hash = "sha256:c2d5a539b0bfe6159d5522c8c70e1c0e487f22c2badae0f97d45246223b798ea", size = 1325374, upload-time = "2026-02-14T18:06:12.804Z" },
-]
-
-[[package]]
-name = "pyinstaller-hooks-contrib"
-version = "2026.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "importlib-metadata", version = "8.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "importlib-metadata", version = "8.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
-    { name = "packaging" },
-    { name = "setuptools", version = "75.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/fe/9278c29394bf69169febc21f96b4252c3ee7c8ec22c2fc545004bed47e71/pyinstaller_hooks_contrib-2026.4.tar.gz", hash = "sha256:766c281acb1ecc32e21c8c667056d7ebf5da0aabd5e30c219f9c2a283620eeaa", size = 173050, upload-time = "2026-03-31T14:10:51.188Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/f4/035fb8c06deff827f540a9a4ed9122c54e5376fca3e42eddf0c263730775/pyinstaller_hooks_contrib-2026.4-py3-none-any.whl", hash = "sha256:1de1a5e49a878122010b88c7e295502bc69776c157c4a4dc78741a4e6178b00f", size = 455496, upload-time = "2026-03-31T14:10:49.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/93/aae15e73855e6e9a327528b506b4ae2e6e0f94d301fed8f27015bbe047e4/pyoxidizer-0.24.0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:eed0f08a38798f14cf0464272552aef97e534b9a418d2a671b8d85ec7af1a237", size = 10386860, upload-time = "2022-12-30T01:38:16.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/bc/ac789f384f84583a5057b6198553e407e1116375cf1840427bad56d1f97f/pyoxidizer-0.24.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1a9940d2bdb6c9e6c6c45eb4de3d4d6e5c9b3a3724dbc7d774d85d4956058447", size = 9705975, upload-time = "2022-12-30T01:38:18.958Z" },
+    { url = "https://files.pythonhosted.org/packages/62/e5/2f5a9cc8fb06aff4fe84299bf7fa9815b1eaee81842137e0e98a45ab1b3e/pyoxidizer-0.24.0-py3-none-manylinux2010_x86_64.whl", hash = "sha256:ec56f2b99495aa0178e927389a3e151e9669beae4e2bce3f6897fb9891b5502e", size = 12356489, upload-time = "2022-12-30T01:38:21.52Z" },
+    { url = "https://files.pythonhosted.org/packages/72/ff/02653151eb66ce7c945ee19aadcbdd5cd6a8e13e201254bb6a787df851dd/pyoxidizer-0.24.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:825d37c8d44971f3e7ca6beed77b560b508c69497f48019428f1aae3fd80c049", size = 11986314, upload-time = "2022-12-30T01:38:23.875Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a5/dea667d142e7fe1df7e0f3436df8e9fbebce0a8538fa06534f28492291fd/pyoxidizer-0.24.0-py3-none-win32.whl", hash = "sha256:4ccc59d157952bccb6ab6897f061966ac31403b2cee18fe9dfbd871f429bd34c", size = 8490488, upload-time = "2022-12-30T01:38:26.078Z" },
+    { url = "https://files.pythonhosted.org/packages/54/b8/0a8b6c744af3d553f0a7ac8affec7d40a9544a08d6c8b84164003c87c133/pyoxidizer-0.24.0-py3-none-win_amd64.whl", hash = "sha256:9b18f8d5f6b309ec856109b2f4d8228bae513da0b0213991e3305cf73583c385", size = 9014460, upload-time = "2022-12-30T01:38:28.125Z" },
 ]
 
 [[package]]
@@ -571,15 +532,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pywin32-ctypes"
-version = "0.2.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
-]
-
-[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -682,31 +634,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964, upload-time = "2026-04-09T14:06:07.14Z" },
     { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044, upload-time = "2026-04-09T14:05:39.473Z" },
     { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607, upload-time = "2026-04-09T14:05:47.593Z" },
-]
-
-[[package]]
-name = "setuptools"
-version = "75.3.4"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/93/d2622cbf262418995140dfc1ddb890badd6322893fa122302577c82b9617/setuptools-75.3.4.tar.gz", hash = "sha256:b4ea3f76e1633c4d2d422a5d68ab35fd35402ad71e6acaa5d7e5956eb47e8887", size = 1354595, upload-time = "2026-02-08T14:12:34.287Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/b1/961ba076c7d3732e3a97e6681c55ef647afb795fe8bfcd27becec8a762ce/setuptools-75.3.4-py3-none-any.whl", hash = "sha256:2dd50a7f42dddfa1d02a36f275dbe716f38ed250224f609d35fb60a09593d93e", size = 1251633, upload-time = "2026-02-08T14:12:32.364Z" },
-]
-
-[[package]]
-name = "setuptools"
-version = "82.0.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bump the Photoshop adapter's `dcc-mcp-core` dependency floor to `>=0.19.17,<1.0.0`.
- Regenerate `uv.lock` so local locked installs carry `dcc-mcp-core 0.19.17` and `dcc-mcp-server 0.19.17`.
- Update public docs that describe the current core/server compatibility floor.

## Root Cause

The standalone PyOxidizer build installs this package and its dependencies from `pyproject.toml`. The package still allowed `dcc-mcp-core>=0.19.9`, so release artifacts could embed the older core/server train instead of the current validated train.

## Validation

- `python -m pip index versions dcc-mcp-core`
- `python -m pip index versions dcc-mcp-server`
- `gh release view v0.19.17 --repo dcc-mcp/dcc-mcp-core --json tagName,assets`
- `uv run pytest tests/ -v --tb=short`
- `python tools\build_binary.py`
- `dist\binary\dcc-mcp-photoshop.exe --version`
- `dist\binary\dcc-mcp-photoshop.exe --help`
- Built `dist\archive\dcc-mcp-photoshop-windows.tar.gz` and verified it contains:
  - `lib/dcc_mcp_core-0.19.17.dist-info/METADATA`
  - `lib/dcc_mcp_server-0.19.17.dist-info/METADATA`
  - `lib/dcc_mcp_photoshop-0.1.26.dist-info/METADATA`
- `uv run --extra dev python -m build`

## Notes

Repo-wide Ruff checks currently fail on pre-existing `tools/*` lint/format issues unrelated to this dependency change.
